### PR TITLE
Always use DateTime.ToString() instead of implicit casting to use current culture instead of invariant one

### DIFF
--- a/Private/Invoke-EventLogVerification.ps1
+++ b/Private/Invoke-EventLogVerification.ps1
@@ -4,8 +4,8 @@ function Invoke-EventLogVerification ($Results, $Dates) {
     foreach ($result in $Results) {
 
         if ($result.EventOldest -gt $Dates.DateFrom) {
-            Write-Color @script:WriteParameters '[W] ', 'Warning: ', $result.LogName, ' log on ', $result.Server, " doesn't cover whole date range requested. Oldest event ", $result.EventOldest, ' while requested ', $Dates.DateFrom, '.' -Color Blue, White, Yellow, White, Yellow, White, Yellow, White, Yellow
-            $Logs += "<strong>$($result.LogName)</strong> log on <strong>$($result.Server)</strong> doesn't cover whole date range requested. Oldest event <strong>$($result.EventOldest)</strong> while requested <strong>$($Dates.DateFrom)</strong>."
+            Write-Color @script:WriteParameters '[W] ', 'Warning: ', $result.LogName, ' log on ', $result.Server, " doesn't cover whole date range requested. Oldest event ", $result.EventOldest.ToString(), ' while requested ', $Dates.DateFrom.ToString(), '.' -Color Blue, White, Yellow, White, Yellow, White, Yellow, White, Yellow
+            $Logs += "<strong>$($result.LogName)</strong> log on <strong>$($result.Server)</strong> doesn't cover whole date range requested. Oldest event <strong>$($result.EventOldest.ToString())</strong> while requested <strong>$($Dates.DateFrom.ToString())</strong>."
         }
     }
     return $Logs

--- a/Private/PSWinReportingEmails.ps1
+++ b/Private/PSWinReportingEmails.ps1
@@ -129,8 +129,8 @@ function Set-EmailReportDetails($FormattingParameters, $Dates, $Warnings) {
     $DateReport = get-date
     # HTML Report settings
     $Report = "<p style=`"background-color:white;font-family:$($FormattingParameters.FontFamily);font-size:$($FormattingParameters.FontSize)`">" +
-    "<strong>Report Time:</strong> $DateReport <br>" +
-    "<strong>Report Period:</strong> $($Dates.DateFrom) to $($Dates.DateTo) <br>" +
+    "<strong>Report Time:</strong> $($DateReport.ToString()) <br>" +
+    "<strong>Report Period:</strong> $($Dates.DateFrom.ToString()) to $($Dates.DateTo.ToString()) <br>" +
     "<strong>Account Executing Report :</strong> $env:userdomain\$($env:username.toupper()) on $($env:ComputerName.toUpper()) <br>" +
     "<strong>Time to generate:</strong> **TimeToGenerateDays** days, **TimeToGenerateHours** hours, **TimeToGenerateMinutes** minutes, **TimeToGenerateSeconds** seconds, **TimeToGenerateMilliseconds** milliseconds"
 

--- a/Private/Start-Report.ps1
+++ b/Private/Start-Report.ps1
@@ -27,7 +27,7 @@ function Start-Report {
     $TableExecutionTimes = ''
     $TableEventLogFiles = @()
 
-    Write-Color @script:WriteParameters '[i] Processing report for dates from: ', $Dates.DateFrom, ' to ', $Dates.DateTo  -Color White, Yellow, White, Yellow
+    Write-Color @script:WriteParameters '[i] Processing report for dates from: ', $Dates.DateFrom.ToString(), ' to ', $Dates.DateTo.ToString()  -Color White, Yellow, White, Yellow
     Write-Color @script:WriteParameters '[i] Establishing servers list to ', 'process...' -Color White, Yellow
 
     $ServersAD = Get-DC
@@ -316,7 +316,7 @@ function Start-Report {
         if ($ReportOptions.SendMailOnlyOnEvents -eq $true -and $AtleastOneEvent -eq $false) {
             Write-Color @script:WriteParameters "[i] Sending email with reports... ", 'Skipped on demand. ', 'No events found.' -Color White, Yellow, Green
         } else {
-            $TemporarySubject = $EmailParameters.EmailSubject -replace "<<DateFrom>>", "$($Dates.DateFrom)" -replace "<<DateTo>>", "$($Dates.DateTo)"
+            $TemporarySubject = $EmailParameters.EmailSubject -replace "<<DateFrom>>", "$($Dates.DateFrom.ToString())" -replace "<<DateTo>>", "$($Dates.DateTo.ToString())"
             Write-Color @script:WriteParameters "[i] Sending email with reports..." -Color White, Green -NoNewLine
             $SendMail = Send-Email -EmailParameters $EmailParameters -Body $EmailBody -Attachment $Reports -Subject $TemporarySubject
             if ($SendMail.Status) {


### PR DESCRIPTION
When converting a DateTime to a string, if `ToString()` is not explicitly called then Powershell use the invariant locale (en-us) instead of the current locale.

For instance on my machine (with French culture fr-fr):
```ps1
> "$(Get-Date)"
02/09/2024 22:29:36 # mm/dd/yyyy

> "$((Get-Date).ToString())"
09/02/2024 22:31:40 # dd/mm/yyyy
``` 

More information here: https://jhoneill.github.io/powershell/2022/03/06/DateFormats.html

So in order to respect the current locale, `ToString()` must be call.