### PR TITLE
(V2) Always use DateTime.ToString() instead of implicit casting to use current culture instead of invariant one

### DIFF
--- a/Private/Main/Start-ReportSpecial.ps1
+++ b/Private/Main/Start-ReportSpecial.ps1
@@ -188,7 +188,7 @@ function Start-ReportSpecial {
             $EmailBody = ''
         }
 
-        $TemporarySubject = $Options.SendMail.Parameters.Subject -replace "<<DateFrom>>", "$($Dates.DateFrom)" -replace "<<DateTo>>", "$($Dates.DateTo)"
+        $TemporarySubject = $Options.SendMail.Parameters.Subject -replace "<<DateFrom>>", "$($Dates.DateFrom.ToString())" -replace "<<DateTo>>", "$($Dates.DateTo.ToString())"
         $Logger.AddInfoRecord('Sending email with reports')
         if ($Options.AsHTML.Formatting.CompanyBranding.Inline) {
             $SendMail = Send-Email -EmailParameters $Options.SendMail.Parameters -Body $EmailBody -Attachment $AttachedReports -Subject $TemporarySubject -InlineAttachments @{logo = $Options.AsHTML.Formatting.CompanyBranding.Logo } -Logger $Logger

--- a/Private/Other/Set-EmailReportDetails.ps1
+++ b/Private/Other/Set-EmailReportDetails.ps1
@@ -3,7 +3,7 @@ function Set-EmailReportDetails($FormattingParameters, $Dates, $Warnings) {
     # HTML Report settings
     $Report = "<p style=`"background-color:white;font-family:$($FormattingParameters.FontFamily);font-size:$($FormattingParameters.FontSize)`">" +
     "<strong>Report Time:</strong> $DateReport <br>" +
-    "<strong>Report Period:</strong> $($Dates.DateFrom) to $($Dates.DateTo) <br>" +
+    "<strong>Report Period:</strong> $($Dates.DateFrom.ToString()) to $($Dates.DateTo.ToString()) <br>" +
     "<strong>Account Executing Report :</strong> $env:userdomain\$($env:username.toupper()) on $($env:ComputerName.toUpper()) <br>" +
     "<strong>Time to generate:</strong> **TimeToGenerateDays** days, **TimeToGenerateHours** hours, **TimeToGenerateMinutes** minutes, **TimeToGenerateSeconds** seconds, **TimeToGenerateMilliseconds** milliseconds"
 

--- a/Public/Find-Events.ps1
+++ b/Public/Find-Events.ps1
@@ -145,7 +145,7 @@ function Find-Events {
                 if (-not $Quiet) { $Logger.AddInfoRecord("File $($Entry.Server) added to scan $($Entry.LogName) log for events: $($Entry.EventID -join ', ')") }
             }
         }
-        if (-not $Quiet) { $Logger.AddInfoRecord("Getting events for dates $($Dates.DateFrom) to $($Dates.DateTo)") }
+        if (-not $Quiet) { $Logger.AddInfoRecord("Getting events for dates $($Dates.DateFrom.ToString()) to $($Dates.DateTo.ToString())") }
         # Scan all events and get everything at once
         $SplatEvents = @{
             Verbose       = $Verbose

--- a/Public/Start-WinReporting.ps1
+++ b/Public/Start-WinReporting.ps1
@@ -23,7 +23,7 @@ function Start-WinReporting {
     # Run report
     $Dates = Get-ChoosenDates -ReportTimes $Times
     foreach ($Date in $Dates) {
-        $Logger.AddInfoRecord("Starting to build a report for dates $($Date.DateFrom) to $($Date.DateTo)")
+        $Logger.AddInfoRecord("Starting to build a report for dates $($Date.DateFrom.ToString()) to $($Date.DateTo.ToString())")
         Start-ReportSpecial -Dates $Date -Options $Options -Definitions $Definitions -Target $Target
     }
 }


### PR DESCRIPTION
This is the exact same PR as #81 but this time targeting the V2 branch.

When converting a DateTime to a string, if `ToString()` is not explicitly called then Powershell use the invariant locale (en-us) instead of the current locale.

For instance on my machine (with French culture fr-fr):
```ps1
> "$(Get-Date)"
02/09/2024 22:29:36 # mm/dd/yyyy

> "$((Get-Date).ToString())"
09/02/2024 22:31:40 # dd/mm/yyyy
``` 

More information here: https://jhoneill.github.io/powershell/2022/03/06/DateFormats.html

So in order to respect the current locale, `ToString()` must be called.