### PR TITLE
Prepare final PSWinReporting 1.x release

### DIFF
--- a/Build/Manage-Module.ps1
+++ b/Build/Manage-Module.ps1
@@ -1,10 +1,24 @@
-Clear-Host
+param(
+    [Alias('ConfigurationGateMode')]
+    [ValidateSet('Manifest', 'Build', 'Publish')]
+    [string] $RunMode = 'Build',
 
-Invoke-ModuleBuild -ModuleName 'PSWinReporting' {
+    [bool] $SignModule = $false,
+
+    [string] $PowerShellGalleryApiKeyPath = 'C:\Support\Important\PowerShellGalleryAPI.txt',
+
+    [string] $GitHubApiKeyPath = 'C:\Support\Important\GitHubAPI.txt'
+)
+
+$ErrorActionPreference = 'Stop'
+
+Import-Module PSPublishModule -Force
+
+Build-Module -ModuleName 'PSWinReporting' {
     # Usual defaults as per standard module
     $Manifest = [ordered] @{
         # Version number of this module.
-        ModuleVersion = '1.8.1.X'
+        ModuleVersion = '1.8.1.7'
         # ID used to uniquely identify this module
         GUID          = '4b446d15-93e7-4eec-a6ee-d741f2ae2f3b'
         # Author of this module
@@ -18,16 +32,16 @@ Invoke-ModuleBuild -ModuleName 'PSWinReporting' {
         # Tags applied to this module. These help with module discovery in online galleries.
         Tags          = @('Windows', 'PSWinReporting', 'ActiveDirectory', 'Events', 'Reporting')
         IconUri       = 'https://evotec.xyz/wp-content/uploads/2018/10/PSWinReporting.png'
-        ProjectUri    = 'https://github.com/EvotecIT/PSWinReporting'
+        ProjectUri    = 'https://github.com/EvotecIT/EventViewerX'
     }
     New-ConfigurationManifest @Manifest #-Prerelease "Alpha02"
 
-    #New-ConfigurationModule -Type RequiredModule -Name 'PSSharedGoods' -Guid Auto -Version Latest
-    New-ConfigurationModule -Type RequiredModule -Name 'PSEventViewer' -Guid Auto -Version 1.0.22
-    New-ConfigurationModule -Type RequiredModule -Name 'PSWriteExcel' -Guid Auto -Version 0.1.15
-    New-ConfigurationModule -Type RequiredModule -Name 'PSWriteColor' -Guid Auto -Version Latest
+    # The final frozen release carries the compatible v1 event-query engine
+    # privately because later PSEventViewer versions changed its contract.
+    New-ConfigurationModule -Type RequiredModule -Name 'PSWriteExcel' -Guid '82232c6a-27f1-435d-a496-929f7221334b' -RequiredVersion '0.1.15'
     New-ConfigurationModule -Type ExternalModule -Name 'ActiveDirectory'
-    New-ConfigurationModule -Type ApprovedModule -Name 'PSSharedGoods', 'PSWriteColor', 'Connectimo', 'PSUnifi', 'PSWebToolbox', 'PSMyPassword'
+    New-ConfigurationModule -Type ApprovedModule -Name 'PSSharedGoods' -RequiredVersion '0.0.312'
+    New-ConfigurationModule -Type ApprovedModule -Name 'PSWriteColor' -RequiredVersion '1.0.3'
 
     New-ConfigurationModuleSkip -IgnoreModuleName @(
         # this are builtin into PowerShell, so not critical
@@ -35,11 +49,14 @@ Invoke-ModuleBuild -ModuleName 'PSWinReporting' {
         'Microsoft.PowerShell.Security'
         'Microsoft.PowerShell.Utility'
         'ScheduledTasks'
+        'PSWriteExcel'
+        'TeamsX'
         # this is optional, and checked for existance in the source codes directly
         'PSTeams'
         'PSSlack'
         'dbatools'
     ) -IgnoreFunctionName @(
+        'ConvertTo-Excel'
         # those functions are internal within private function
         'Select-Unique', 'Compare-TwoArrays', 'IsNumeric', 'IsOfType', 'Format-HTML', 'Optimize-HTML'
         # Special nofunctions
@@ -47,9 +64,16 @@ Invoke-ModuleBuild -ModuleName 'PSWinReporting' {
         'eventID'
         'eventRecordID'
         'eventSeverity'
+        # Nested inside the frozen legacy event-query scriptblock.
+        'Get-EventsFilter'
+        'Get-EventsInternal'
+        'Initialize-XPathFilter'
+        'Join-XPathFilter'
         # slack
         'New-SlackMessage'
         'New-SlackMessageAttachment'
+        'New-TeamsFact'
+        'New-TeamsSection'
         'Send-SlackMessage'
         # dbatools
         'Invoke-DbaQuery'
@@ -96,18 +120,15 @@ Invoke-ModuleBuild -ModuleName 'PSWinReporting' {
     # when creating PSD1 use special style without comments and with only required parameters
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
     # configuration for documentation, at the same time it enables documentation processing
-    New-ConfigurationDocumentation -Enable:$false -StartClean -UpdateWhenNew -PathReadme 'Docs\Readme.md' -Path 'Docs'
-
-    New-ConfigurationImportModule -ImportSelf
-
-    New-ConfigurationBuild -Enable:$true -SignModule -MergeModuleOnBuild -MergeFunctionsFromApprovedModules -CertificateThumbprint '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
+    New-ConfigurationBuild -Enable -SignModule:$SignModule -MergeModuleOnBuild -MergeFunctionsFromApprovedModules -ResolveMissingModulesOnline -DeleteTargetModuleBeforeBuild -CertificateThumbprint '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
 
     #New-ConfigurationTest -TestsPath "$PSScriptRoot\..\Tests" -Enable
 
-    New-ConfigurationArtefact -Type Unpacked -Enable -Path "$PSScriptRoot\..\Artefacts\Unpacked" -AddRequiredModules
+    New-ConfigurationArtefact -Type Unpacked -Enable -Path "$PSScriptRoot\..\Artefacts\Unpacked" -AddRequiredModules -RequiredModulesSource Download -RequiredModulesRepository 'PSGallery'
     New-ConfigurationArtefact -Type Packed -Enable -Path "$PSScriptRoot\..\Artefacts\Packed" -ArtefactName '<ModuleName>.v<ModuleVersion>.zip'
 
-    # options for publishing to github/psgallery
-    #New-ConfigurationPublish -Type PowerShellGallery -FilePath 'C:\Support\Important\PowerShellGalleryAPI.txt' -Enabled:$true
-    #New-ConfigurationPublish -Type GitHub -FilePath 'C:\Support\Important\GitHubAPI.txt' -UserName 'EvotecIT' -Enabled:$true
-} -ExitCode
+    New-ConfigurationPublish -Type PowerShellGallery -FilePath $PowerShellGalleryApiKeyPath -Enabled:$false
+    New-ConfigurationPublish -Type GitHub -FilePath $GitHubApiKeyPath -UserName 'EvotecIT' -RepositoryName 'EventViewerX' -Enabled:$false -GenerateReleaseNotes -OverwriteTagName '{ModuleName}-v{ModuleVersionWithPreRelease}'
+
+    New-ConfigurationGate -Mode $RunMode
+}

--- a/Build/Manage-Module.ps1
+++ b/Build/Manage-Module.ps1
@@ -39,9 +39,9 @@ Build-Module -ModuleName 'PSWinReporting' {
     # The final frozen release carries the compatible v1 event-query engine
     # privately because later PSEventViewer versions changed its contract.
     New-ConfigurationModule -Type RequiredModule -Name 'PSWriteExcel' -Guid '82232c6a-27f1-435d-a496-929f7221334b' -RequiredVersion '0.1.15'
+    New-ConfigurationModule -Type RequiredModule -Name 'PSSharedGoods' -Guid 'ee272aa8-baaa-4edf-9f45-b6d6f7d844fe' -RequiredVersion '0.0.312'
+    New-ConfigurationModule -Type RequiredModule -Name 'PSWriteColor' -Guid '0b0ba5c5-ec85-4c2b-a718-874e55a8bc3f' -RequiredVersion '1.0.3'
     New-ConfigurationModule -Type ExternalModule -Name 'ActiveDirectory'
-    New-ConfigurationModule -Type ApprovedModule -Name 'PSSharedGoods' -RequiredVersion '0.0.312'
-    New-ConfigurationModule -Type ApprovedModule -Name 'PSWriteColor' -RequiredVersion '1.0.3'
 
     New-ConfigurationModuleSkip -IgnoreModuleName @(
         # this are builtin into PowerShell, so not critical
@@ -67,6 +67,7 @@ Build-Module -ModuleName 'PSWinReporting' {
         # Nested inside the frozen legacy event-query scriptblock.
         'Get-EventsFilter'
         'Get-EventsInternal'
+        'ConvertTo-XPathXmlLiteral'
         'Initialize-XPathFilter'
         'Join-XPathFilter'
         # slack
@@ -120,7 +121,7 @@ Build-Module -ModuleName 'PSWinReporting' {
     # when creating PSD1 use special style without comments and with only required parameters
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
     # configuration for documentation, at the same time it enables documentation processing
-    New-ConfigurationBuild -Enable -SignModule:$SignModule -MergeModuleOnBuild -MergeFunctionsFromApprovedModules -ResolveMissingModulesOnline -DeleteTargetModuleBeforeBuild -CertificateThumbprint '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
+    New-ConfigurationBuild -Enable -SignModule:$SignModule -MergeModuleOnBuild -ResolveMissingModulesOnline -DeleteTargetModuleBeforeBuild -CertificateThumbprint '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
 
     #New-ConfigurationTest -TestsPath "$PSScriptRoot\..\Tests" -Enable
 

--- a/Build/Manage-Module.ps1
+++ b/Build/Manage-Module.ps1
@@ -70,6 +70,9 @@ Build-Module -ModuleName 'PSWinReporting' {
         'ConvertTo-XPathXmlLiteral'
         'Initialize-XPathFilter'
         'Join-XPathFilter'
+        'Test-NamedDataMatch'
+        'Test-NamedDataRequiresPostFilter'
+        'Test-XPathLiteralRequiresPostFilter'
         # slack
         'New-SlackMessage'
         'New-SlackMessageAttachment'

--- a/PSWinReporting.psd1
+++ b/PSWinReporting.psd1
@@ -23,6 +23,14 @@
             Guid            = '82232c6a-27f1-435d-a496-929f7221334b'
             ModuleName      = 'PSWriteExcel'
             RequiredVersion = '0.1.15'
+        }, @{
+            Guid            = 'ee272aa8-baaa-4edf-9f45-b6d6f7d844fe'
+            ModuleName      = 'PSSharedGoods'
+            RequiredVersion = '0.0.312'
+        }, @{
+            Guid            = '0b0ba5c5-ec85-4c2b-a718-874e55a8bc3f'
+            ModuleName      = 'PSWriteColor'
+            RequiredVersion = '1.0.3'
         })
     RootModule           = 'PSWinReporting.psm1'
     ScriptsToProcess     = @()

--- a/PSWinReporting.psd1
+++ b/PSWinReporting.psd1
@@ -4,7 +4,7 @@
     CmdletsToExport      = @()
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
-    Copyright            = '(c) 2011 - 2024 Przemyslaw Klys @ Evotec. All rights reserved.'
+    Copyright            = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'
     Description          = 'This PowerShell Module, which started as an event library (Get-EventsLibrary.ps1), has now grown up and became full fledged PowerShell Module. This module has multiple functionalities but one of the signature features of this module is ability to parse Security (mostly) logs on Domain Controllers.'
     FunctionsToExport    = @('Add-TaskScheduledForwarder', 'New-SubscriptionTemplates', 'Remove-TaskScheduledForwarder', 'Set-SubscriptionTemplates', 'Start-ADReporting', 'Start-Notifications', 'Start-RescanEvents', 'Start-SubscriptionService')
     GUID                 = '4b446d15-93e7-4eec-a6ee-d741f2ae2f3b'
@@ -14,22 +14,16 @@
         PSData = @{
             ExternalModuleDependencies = @('ActiveDirectory')
             IconUri                    = 'https://evotec.xyz/wp-content/uploads/2018/10/PSWinReporting.png'
-            ProjectUri                 = 'https://github.com/EvotecIT/PSWinReporting'
+            ProjectUri                 = 'https://github.com/EvotecIT/EventViewerX'
             Tags                       = @('Windows', 'PSWinReporting', 'ActiveDirectory', 'Events', 'Reporting')
+            RequireLicenseAcceptance   = $false
         }
     }
     RequiredModules      = @(@{
-            Guid          = '5df72a79-cdf6-4add-b38d-bcacf26fb7bc'
-            ModuleName    = 'PSEventViewer'
-            ModuleVersion = '1.0.22'
-        }, @{
-            Guid          = '82232c6a-27f1-435d-a496-929f7221334b'
-            ModuleName    = 'PSWriteExcel'
-            ModuleVersion = '0.1.15'
-        }, @{
-            Guid          = '0b0ba5c5-ec85-4c2b-a718-874e55a8bc3f'
-            ModuleName    = 'PSWriteColor'
-            ModuleVersion = '1.0.1'
-        }, 'ActiveDirectory')
+            Guid            = '82232c6a-27f1-435d-a496-929f7221334b'
+            ModuleName      = 'PSWriteExcel'
+            RequiredVersion = '0.1.15'
+        })
     RootModule           = 'PSWinReporting.psm1'
+    ScriptsToProcess     = @()
 }

--- a/Private/Add-ToHashTable.ps1
+++ b/Private/Add-ToHashTable.ps1
@@ -1,0 +1,5 @@
+function Add-ToHashTable($Hashtable, $Key, $Value) {
+    if ($null -ne $Value -and $Value -ne '') {
+        $Hashtable.Add($Key, $Value)
+    }
+}

--- a/Private/Add-ToHashTable.ps1
+++ b/Private/Add-ToHashTable.ps1
@@ -1,5 +1,7 @@
 function Add-ToHashTable($Hashtable, $Key, $Value) {
-    if ($null -ne $Value -and $Value -ne '') {
+    if ($null -ne $Value -and
+        -not ($Value -is [string] -and $Value.Length -eq 0) -and
+        -not ($Value -is [System.Collections.ICollection] -and $Value.Count -eq 0)) {
         $Hashtable.Add($Key, $Value)
     }
 }

--- a/Private/Dates/Find-DatesQuarterLast.ps1
+++ b/Private/Dates/Find-DatesQuarterLast.ps1
@@ -19,12 +19,15 @@ function Find-DatesQuarterLast ([bool] $Force) {
 
     #>
     #https://blogs.technet.microsoft.com/dsheehan/2017/09/21/use-powershell-to-determine-the-first-day-of-the-current-calendar-quarter/
-    $Today = (Get-Date).AddDays(-90)
-    $Yesterday = ((Get-Date).AddDays(-1))
-    $Quarter = [Math]::Ceiling($Today.Month / 3)
-    $LastDay = [DateTime]::DaysInMonth([Int]$Today.Year.ToString(), [Int]($Quarter * 3))
-    $StartDate = (get-date -Year $Today.Year -Month ($Quarter * 3 - 2) -Day 1).Date
-    $EndDate = (get-date -Year $Today.Year -Month ($Quarter * 3) -Day $LastDay).Date.AddDays(1).AddTicks(-1)
+    $Today = Get-Date
+    $Yesterday = $Today.AddDays(-1)
+    $CurrentQuarter = [Math]::Ceiling($Today.Month / 3)
+    $CurrentQuarterStart = (Get-Date -Year $Today.Year -Month ($CurrentQuarter * 3 - 2) -Day 1).Date
+    $PreviousQuarterDate = $CurrentQuarterStart.AddDays(-1)
+    $Quarter = [Math]::Ceiling($PreviousQuarterDate.Month / 3)
+    $LastDay = [DateTime]::DaysInMonth($PreviousQuarterDate.Year, [Int]($Quarter * 3))
+    $StartDate = (Get-Date -Year $PreviousQuarterDate.Year -Month ($Quarter * 3 - 2) -Day 1).Date
+    $EndDate = (Get-Date -Year $PreviousQuarterDate.Year -Month ($Quarter * 3) -Day $LastDay).Date.AddDays(1).AddTicks(-1)
 
     if ($Force -eq $true -or $Yesterday.Date -eq $EndDate.Date) {
         $DateParameters = @{

--- a/Private/Email/Send-Email.ps1
+++ b/Private/Email/Send-Email.ps1
@@ -59,7 +59,7 @@ function Send-Email {
             $EmailParameters = $Email.Clone()
             $EmailParameters.EmailEncoding = $EmailParameters.EmailEncoding -replace "-", ''
             $EmailParameters.EmailEncodingSubject = $EmailParameters.EmailEncodingSubject -replace "-", ''
-            $EmailParameters.EmailEncodingBody = $EmailParameters.EmailEncodingSubject -replace "-", ''
+            $EmailParameters.EmailEncodingBody = $EmailParameters.EmailEncodingBody -replace "-", ''
             $EmailParameters.EmailEncodingAlternateView = $EmailParameters.EmailEncodingAlternateView -replace "-", ''
         } else {
             $EmailParameters = @{

--- a/Private/Get-Events.ps1
+++ b/Private/Get-Events.ps1
@@ -1,0 +1,358 @@
+function Get-Events {
+    <#
+    .SYNOPSIS
+    Get-Events is a wrapper function around Get-WinEvent providing additional features and options.
+
+    .DESCRIPTION
+    Get-Events is a wrapper function around Get-WinEvent providing additional features and options exposing most of the Get-WinEvent functionality in easy to use manner.
+
+    .PARAMETER Machine
+    Specifies the name of the computer that this cmdlet gets events from the event logs. Type the NetBIOS name, an IP address, or the fully qualified domain name (FQDN) of the computer. The default value is the local computer, localhost. This parameter accepts only one computer name at a time.
+
+    To get event logs from remote computers, configure the firewall port for the event log service to allow remote access.
+
+    This cmdlet does not rely on PowerShell remoting. You can use the ComputerName parameter even if your computer is not configured to run remote commands.
+
+    .PARAMETER DateFrom
+    Specifies the date and time of the earliest event in the event log you want to search for.
+
+    .PARAMETER DateTo
+    Specifies the date and time of the latest event in the event log you want to search for.
+
+    .PARAMETER ID
+    Specifies the event ID (or events) of the event you want to search for. If provided more than 23 the cmdlet will split the events into multiple queries automatically.
+
+    .PARAMETER ExcludeID
+    Specifies the event ID (or events) of the event you want to exclude from the search. If provided more than 23 the cmdlet will split the events into multiple queries automatically.
+
+    .PARAMETER LogName
+    Specifies the event logs that this cmdlet get events from. Enter the event log names in a comma-separated list. Wildcards are permitted.
+
+    .PARAMETER ProviderName
+    Specifies, as a string array, the event log providers from which this cmdlet gets events. Enter the provider names in a comma-separated list, or use wildcard characters to create provider name patterns.
+
+    An event log provider is a program or service that writes events to the event log. It is not a PowerShell provider.
+
+    .PARAMETER NamedDataFilter
+    Provide NamedDataFilter in specific form to optimize search performance looking for specific events.
+
+    .PARAMETER NamedDataExcludeFilter
+    Provide NamedDataExcludeFilter in specific form to optimize search performance looking for specific events.
+
+    .PARAMETER UserID
+    The UserID key can take a valid security identifier (SID) or a domain account name that can be used to construct a valid System.Security.Principal.NTAccount object.
+
+    .PARAMETER Level
+    Define the event level that this cmdlet gets events from. Options are Verbose, Informational, Warning, Error, Critical, LogAlways
+
+    .PARAMETER UserSID
+    Search events by UserSID
+
+    .PARAMETER Data
+    The Data value takes event data in an unnamed field. For example, events in classic event logs.
+
+    .PARAMETER MaxEvents
+    Specifies the maximum number of events that are returned. Enter an integer such as 100. The default is to return all the events in the logs or files.
+
+    .PARAMETER Credential
+    Specifies the name of the computer that this cmdlet gets events from the event logs. Type the NetBIOS name, an IP address, or the fully qualified domain name (FQDN) of the computer. The default value is the local computer, localhost. This parameter accepts only one computer name at a time.
+
+    To get event logs from remote computers, configure the firewall port for the event log service to allow remote access.
+
+    This cmdlet does not rely on PowerShell remoting. You can use the ComputerName parameter even if your computer is not configured to run remote commands.
+
+    .PARAMETER Path
+    Specifies the path to the event log files that this cmdlet get events from. Enter the paths to the log files in a comma-separated list, or use wildcard characters to create file path patterns.
+
+    .PARAMETER Keywords
+    Define keywords to search for by their name. Available keywords are: AuditFailure, AuditSuccess, CorrelationHint2, EventLogClassic, Sqm, WdiDiagnostic, WdiContext, ResponseTime, None
+
+    .PARAMETER RecordID
+    Find a single event in the event log using it's RecordId
+
+    .PARAMETER MaxRunspaces
+    Limit the number of concurrent runspaces that can be used to process the events. By default it uses $env:NUMBER_OF_PROCESSORS + 1
+
+    .PARAMETER Oldest
+    Indicate that this cmdlet gets the events in oldest-first order. By default, events are returned in newest-first order.
+
+    .PARAMETER DisableParallel
+    Disables parallel processing of the events. By default, events are processed in parallel.
+
+    .PARAMETER ExtendedOutput
+    Indicates that this cmdlet returns an extended set of output parameters. By default, this cmdlet does not generate any extended output.
+
+    .PARAMETER ExtendedInput
+    Indicates that this cmdlet takes an extended set of input parameters. Extended input is used by PSWinReportingV2 to provide special input parameters.
+
+    .EXAMPLE
+    Get-Events -LogName 'Application' -ID 1001 -MaxEvents 1 -Verbose -DisableParallel
+
+    .EXAMPLE
+    Get-Events -LogName 'Setup' -ID 2 -ComputerName 'AD1' -MaxEvents 1 -Verbose | Format-List *
+
+    .EXAMPLE
+    Get-Events -LogName 'Setup' -ID 2 -ComputerName 'AD1','AD2','AD3' -MaxEvents 1 -Verbose | Format-List *
+
+    .EXAMPLE
+    Get-Events -LogName 'Security' -ID 5379 -RecordID 19626 -Verbose
+
+    .EXAMPLE
+    Get-Events -LogName 'System' -ID 1001,1018 -ProviderName 'Microsoft-Windows-WER-SystemErrorReporting' -Verbose
+    Get-Events -LogName 'System' -ID 42,41,109 -ProviderName 'Microsoft-Windows-Kernel-Power' -Verbose
+    Get-Events -LogName 'System' -ID 1,12,13 -ProviderName 'Microsoft-Windows-Kernel-General' -Verbose
+    Get-Events -LogName 'System' -ID 6005,6006,6008,6013 -ProviderName 'EventLog' -Verbose
+
+    .EXAMPLE
+    $List = @(
+        @{ Server = 'AD1'; LogName = 'Security'; EventID = '5136', '5137'; Type = 'Computer' }
+        @{ Server = 'AD2'; LogName = 'Security'; EventID = '5136', '5137'; Type = 'Computer' }
+        @{ Server = 'C:\MyEvents\Archive-Security-2018-08-21-23-49-19-424.evtx'; LogName = 'Security'; EventID = '5136', '5137'; Type = 'File' }
+        @{ Server = 'C:\MyEvents\Archive-Security-2018-09-15-09-27-52-679.evtx'; LogName = 'Security'; EventID = '5136', '5137'; Type = 'File' }
+        @{ Server = 'Evo1'; LogName = 'Setup'; EventID = 2; Type = 'Computer'; }
+        @{ Server = 'AD1.ad.evotec.xyz'; LogName = 'Security'; EventID = 4720, 4738, 5136, 5137, 5141, 4722, 4725, 4767, 4723, 4724, 4726, 4728, 4729, 4732, 4733, 4746, 4747, 4751, 4752, 4756, 4757, 4761, 4762, 4785, 4786, 4787, 4788, 5136, 5137, 5141, 5136, 5137, 5141, 5136, 5137, 5141; Type = 'Computer' }
+        @{ Server = 'Evo1'; LogName = 'Security'; Type = 'Computer'; MaxEvents = 15; Keywords = 'AuditSuccess' }
+        @{ Server = 'Evo1'; LogName = 'Security'; Type = 'Computer'; MaxEvents = 15; Level = 'Informational'; Keywords = 'AuditFailure' }
+    )
+    $Output = Get-Events -ExtendedInput $List -Verbose
+    $Output | Format-Table Computer, Date, LevelDisplayName
+
+    .EXAMPLE
+    Get-Events -MaxEvents 2 -LogName 'Security' -ComputerName 'AD1.AD.EVOTEC.XYZ','AD2' -ID 4720, 4738, 5136, 5137, 5141, 4722, 4725, 4767, 4723, 4724, 4726, 4728, 4729, 4732, 4733, 4746, 4747, 4751, 4752, 4756, 4757, 4761, 4762, 4785, 4786, 4787, 4788, 5136, 5137, 5141, 5136, 5137, 5141, 5136, 5137, 5141 -Verbose
+
+    .NOTES
+    General notes
+    #>
+    [CmdLetBinding()]
+    param (
+        [alias ("ADDomainControllers", "DomainController", "Server", "Servers", "Computer", "Computers", "ComputerName")] [string[]] $Machine = $Env:COMPUTERNAME,
+        [alias ("StartTime", "From")][nullable[DateTime]] $DateFrom = $null,
+        [alias ("EndTime", "To")][nullable[DateTime]] $DateTo = $null,
+        [alias ("Ids", "EventID", "EventIds")] [int[]] $ID = $null,
+        [alias ("ExludeEventID")][int[]] $ExcludeID = $null,
+        [alias ("LogType", "Log")][string] $LogName = $null,
+        [alias ("Provider", "Source")] [string[]] $ProviderName,
+        [hashtable] $NamedDataFilter,
+        [hashtable] $NamedDataExcludeFilter,
+        [string[]] $UserID,
+        [ValidateSet('Verbose', 'Informational', 'Warning', 'Error', 'Critical', 'LogAlways')]
+        [string[]] $Level = $null,
+        [string] $UserSID = $null,
+        [string[]]$Data = $null,
+        [int] $MaxEvents = $null,
+
+        [ValidateNotNull()]
+        [alias('Credentials')][System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]$Credential = [System.Management.Automation.PSCredential]::Empty,
+
+        [string] $Path = $null,
+        [ValidateSet('AuditFailure', 'AuditSuccess', 'CorrelationHint2', 'EventLogClassic', 'Sqm', 'WdiDiagnostic', 'WdiContext', 'ResponseTime', 'None')]
+        [string[]] $Keywords = $null,
+        [alias("EventRecordID")][int64] $RecordID,
+        [int] $MaxRunspaces = [int]$env:NUMBER_OF_PROCESSORS + 1,
+        [switch] $Oldest,
+        [switch] $DisableParallel,
+        [switch] $ExtendedOutput,
+        [Array] $ExtendedInput
+    )
+    if ($PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent) { $Verbose = $true } else { $Verbose = $false }
+
+    $LegacyLevelValues = @{
+        Verbose       = 5
+        Informational = 4
+        Warning       = 3
+        Error         = 2
+        Critical      = 1
+        LogAlways     = 0
+    }
+    $LegacyKeywordValues = @{
+        AuditFailure     = [long] 4503599627370496
+        AuditSuccess     = [long] 9007199254740992
+        CorrelationHint2 = [long] 18014398509481984
+        EventLogClassic  = [long] 36028797018963968
+        Sqm              = [long] 2251799813685248
+        WdiDiagnostic    = [long] 1125899906842624
+        WdiContext       = [long] 562949953421312
+        ResponseTime     = [long] 281474976710656
+        None             = [long] 0
+    }
+
+    $MeasureTotal = [System.Diagnostics.Stopwatch]::StartNew() # Timer Start
+    $ParametersList = [System.Collections.Generic.List[Object]]::new()
+
+    if ($ExtendedInput.Count -gt 0) {
+        # Special input - PSWinReporting requires it
+        [Array] $Param = foreach ($EventEntry in $ExtendedInput) {
+            $EventFilter = @{ }
+            if ($EventEntry.Type -eq 'File') {
+                Write-Verbose "Get-Events - Preparing data to scan file $($EventEntry.Server)"
+                Add-ToHashTable -Hashtable $EventFilter -Key "Path" -Value $EventEntry.Server
+                $Comp = $Env:COMPUTERNAME
+            } else {
+                Write-Verbose "Get-Events - Preparing data to scan computer $($EventEntry.Server)"
+                $Comp = $EventEntry.Server
+                Add-ToHashTable -Hashtable $EventFilter -Key "LogName" -Value $EventEntry.LogName
+            }
+            $ConvertedLevels = foreach ($DataLevel in $EventEntry.Level) {
+                $LegacyLevelValues[[string] $DataLevel]
+            }
+            $ConvertedKeywords = foreach ($DataKeyword in $EventEntry.Keywords) {
+                $LegacyKeywordValues[[string] $DataKeyword]
+            }
+            Add-ToHashTable -Hashtable $EventFilter -Key "StartTime" -Value $EventEntry.DateFrom
+            Add-ToHashTable -Hashtable $EventFilter -Key "EndTime" -Value $EventEntry.DateTo
+            Add-ToHashTable -Hashtable $EventFilter -Key "Keywords" -Value $ConvertedKeywords
+            Add-ToHashTable -Hashtable $EventFilter -Key "Level" -Value $ConvertedLevels
+            Add-ToHashTable -Hashtable $EventFilter -Key "UserID" -Value $EventEntry.UserSID
+            Add-ToHashTable -Hashtable $EventFilter -Key "Data" -Value $EventEntry.Data
+            Add-ToHashTable -Hashtable $EventFilter -Key "RecordID" -Value $EventEntry.RecordID
+            Add-ToHashTable -Hashtable $EventFilter -Key "NamedDataFilter" -Value $EventEntry.NamedDataFilter
+            Add-ToHashTable -Hashtable $EventFilter -Key "NamedDataExcludeFilter" -Value $EventEntry.NamedDataExcludeFilter
+            Add-ToHashTable -Hashtable $EventFilter -Key "UserID" -Value $EventEntry.UserID
+            Add-ToHashTable -Hashtable $EventFilter -Key "ExcludeID" -Value $EventEntry.ExcludeID
+
+            if ($Verbose) {
+                foreach ($Key in $EventFilter.Keys) {
+                    if ($Key -eq 'NamedDataFilter' -or $Key -eq 'NamedDataExcludeFilter') {
+                        foreach ($SubKey in $($EventFilter.$Key).Keys) {
+                            Write-Verbose "Get-Events - Filter parameters provided $Key with SubKey $SubKey = $(($EventFilter.$Key.$SubKey) -join ', ')"
+                        }
+                    } else {
+                        Write-Verbose "Get-Events - Filter parameters provided $Key = $(($EventFilter.$Key) -join ', ')"
+                    }
+                }
+            }
+            if ($null -ne $EventEntry.EventID) {
+                $ID = $EventEntry.EventID | Sort-Object -Unique
+                Write-Verbose "Get-Events - Events to process in Total (unique): $($Id.Count)"
+                Write-Verbose "Get-Events - Events to process in Total ID: $($ID -join ', ')"
+                if ($Id.Count -gt 22) {
+                    Write-Verbose "Get-Events - There are more events to process then 22, split will be required."
+                }
+                $SplitArrayID = Split-Array -inArray $ID -size 22  # Support for more ID's then 22 (limitation of Get-WinEvent)
+                foreach ($EventIdGroup in $SplitArrayID) {
+                    $EventFilter.Id = @($EventIdGroup)
+                    @{
+                        Comp        = $Comp
+                        Credential  = $Credential
+                        EventFilter = $EventFilter.Clone()
+                        MaxEvents   = $EventEntry.MaxEvents
+                        Oldest      = $Oldest
+                        Verbose     = $Verbose
+                    }
+                }
+            } else {
+                @{
+                    Comp        = $Comp
+                    Credential  = $Credential
+                    EventFilter = $EventFilter
+                    MaxEvents   = $EventEntry.MaxEvents
+                    Oldest      = $Oldest
+                    Verbose     = $Verbose
+                }
+            }
+        }
+        if ($null -ne $Param) {
+            $null = $ParametersList.AddRange($Param)
+        }
+    } else {
+        # Standard input
+        $EventFilter = @{ }
+        if ($Path) {
+            Add-ToHashTable -Hashtable $EventFilter -Key "Path" -Value $Path # https://blogs.technet.microsoft.com/heyscriptingguy/2011/01/25/use-powershell-to-parse-saved-event-logs-for-errors/
+        } else {
+            Add-ToHashTable -Hashtable $EventFilter -Key "LogName" -Value $LogName # Accepts Wildcard
+        }
+        Add-ToHashTable -Hashtable $EventFilter -Key "ProviderName" -Value $ProviderName # Accepts Wildcard
+        [array] $ConvertedKeywords = foreach ($DataKeyword in $Keywords) {
+            $LegacyKeywordValues[[string] $DataKeyword]
+        }
+        [array] $ConvertedLevels = foreach ($DataLevel in $Level) {
+            $LegacyLevelValues[[string] $DataLevel]
+        }
+        Add-ToHashTable -Hashtable $EventFilter -Key "Keywords" -Value $ConvertedKeywords
+        Add-ToHashTable -Hashtable $EventFilter -Key "Level" -Value $ConvertedLevels
+        Add-ToHashTable -Hashtable $EventFilter -Key "StartTime" -Value $DateFrom
+        Add-ToHashTable -Hashtable $EventFilter -Key "EndTime" -Value $DateTo
+        Add-ToHashTable -Hashtable $EventFilter -Key "UserID" -Value $UserSID
+        Add-ToHashTable -Hashtable $EventFilter -Key "Data" -Value $Data
+        Add-ToHashTable -Hashtable $EventFilter -Key "RecordID" -Value $RecordID
+        Add-ToHashTable -Hashtable $EventFilter -Key "NamedDataFilter" -Value $NamedDataFilter
+        Add-ToHashTable -Hashtable $EventFilter -Key "NamedDataExcludeFilter" -Value $NamedDataExcludeFilter
+        Add-ToHashTable -Hashtable $EventFilter -Key "UserID" -Value $UserID
+        Add-ToHashTable -Hashtable $EventFilter -Key "ExcludeID" -Value $ExcludeID
+
+        [Array] $Param = foreach ($Comp in $Machine) {
+            if ($Verbose) {
+                Write-Verbose "Get-Events - Preparing data to scan computer $Comp"
+                foreach ($Key in $EventFilter.Keys) {
+                    if ($Key -eq 'NamedDataFilter' -or $Key -eq 'NamedDataExcludeFilter') {
+                        foreach ($SubKey in $($EventFilter.$Key).Keys) {
+                            Write-Verbose "Get-Events - Filter parameters provided $Key with SubKey $SubKey = $(($EventFilter.$Key.$SubKey) -join ', ')"
+                        }
+                    } else {
+                        Write-Verbose "Get-Events - Filter parameters provided $Key = $(($EventFilter.$Key) -join ', ')"
+                    }
+                }
+            }
+            if ($null -ne $ID) {
+                # EventID needed
+                $ID = $ID | Sort-Object -Unique
+                Write-Verbose "Get-Events - Events to process in Total (unique): $($Id.Count)"
+                Write-Verbose "Get-Events - Events to process in Total ID: $($ID -join ', ')"
+                if ($Id.Count -gt 22) {
+                    Write-Verbose "Get-Events - There are more events to process then 22, split will be required."
+                }
+                $SplitArrayID = Split-Array -inArray $ID -size 22  # Support for more ID's then 22 (limitation of Get-WinEvent)
+                foreach ($EventIdGroup in $SplitArrayID) {
+                    $EventFilter.Id = @($EventIdGroup)
+                    @{
+                        Comp        = $Comp
+                        Credential  = $Credential
+                        EventFilter = $EventFilter.Clone()
+                        MaxEvents   = $MaxEvents
+                        Oldest      = $Oldest
+                        Verbose     = $Verbose
+                    }
+                }
+            } else {
+                # No EventID given
+                @{
+                    Comp        = $Comp
+                    Credential  = $Credential
+                    EventFilter = $EventFilter
+                    MaxEvents   = $MaxEvents
+                    Oldest      = $Oldest
+                    Verbose     = $Verbose
+                }
+            }
+        }
+        if ($null -ne $Param) {
+            $null = $ParametersList.AddRange($Param)
+        }
+    }
+    $AllErrors = @()
+    if ($DisableParallel) {
+        Write-Verbose 'Get-Events - Running query with parallel disabled...'
+        [Array] $AllEvents = foreach ($Parameter in $ParametersList) {
+            Invoke-Command -ScriptBlock $Script:ScriptBlock -ArgumentList $Parameter.Comp, $Parameter.Credential, $Parameter.EventFilter, $Parameter.MaxEvents, $Parameter.Oldest, $Parameter.Verbose
+        }
+    } else {
+        Write-Verbose 'Get-Events - Running query with parallel enabled...'
+        $RunspacePool = New-Runspace -maxRunspaces $maxRunspaces -Verbose:$Verbose
+        $Runspaces = foreach ($Parameter in $ParametersList) {
+            Start-Runspace -ScriptBlock $Script:ScriptBlock -Parameters $Parameter -RunspacePool $RunspacePool -Verbose:$Verbose
+        }
+        [Array] $AllEvents = Stop-Runspace -Runspaces $Runspaces -FunctionName "Get-Events" -RunspacePool $RunspacePool -Verbose:$Verbose -ErrorAction SilentlyContinue -ErrorVariable +AllErrors -ExtendedOutput:$ExtendedOutput
+    }
+    Write-Verbose "Get-Events - Overall errors: $($AllErrors.Count)"
+    Write-Verbose "Get-Events - Overall events processed in total for the report: $($AllEvents.Count)"
+    Write-Verbose "Get-Events - Overall time to generate $($MeasureTotal.Elapsed.Hours) hours, $($MeasureTotal.Elapsed.Minutes) minutes, $($MeasureTotal.Elapsed.Seconds) seconds, $($MeasureTotal.Elapsed.Milliseconds) milliseconds"
+    $MeasureTotal.Stop()
+    Write-Verbose "Get-Events - Overall events processing end"
+    if ($AllEvents.Count -eq 1) {
+        return , $AllEvents
+    } else {
+        return $AllEvents
+    }
+}

--- a/Private/Get-Events.ps1
+++ b/Private/Get-Events.ps1
@@ -222,14 +222,19 @@ function Get-Events {
                     }
                 }
             }
-            if ($null -ne $EventEntry.EventID) {
-                $ID = $EventEntry.EventID | Sort-Object -Unique
-                Write-Verbose "Get-Events - Events to process in Total (unique): $($Id.Count)"
-                Write-Verbose "Get-Events - Events to process in Total ID: $($ID -join ', ')"
-                if ($Id.Count -gt 22) {
+            $EventIds = if ($null -ne $EventEntry.EventID) {
+                $EventEntry.EventID
+            } else {
+                $ID
+            }
+            if ($null -ne $EventIds) {
+                $EventIds = $EventIds | Sort-Object -Unique
+                Write-Verbose "Get-Events - Events to process in Total (unique): $($EventIds.Count)"
+                Write-Verbose "Get-Events - Events to process in Total ID: $($EventIds -join ', ')"
+                if ($EventIds.Count -gt 22) {
                     Write-Verbose "Get-Events - There are more events to process then 22, split will be required."
                 }
-                $SplitArrayID = Split-Array -inArray $ID -size 22  # Support for more ID's then 22 (limitation of Get-WinEvent)
+                $SplitArrayID = Split-Array -inArray $EventIds -size 22  # Support for more ID's then 22 (limitation of Get-WinEvent)
                 foreach ($EventIdGroup in $SplitArrayID) {
                     $EventFilter.Id = @($EventIdGroup)
                     @{

--- a/Private/Get-Events.ps1
+++ b/Private/Get-Events.ps1
@@ -148,7 +148,7 @@ function Get-Events {
         [string] $Path = $null,
         [ValidateSet('AuditFailure', 'AuditSuccess', 'CorrelationHint2', 'EventLogClassic', 'Sqm', 'WdiDiagnostic', 'WdiContext', 'ResponseTime', 'None')]
         [string[]] $Keywords = $null,
-        [alias("EventRecordID")][int64] $RecordID,
+        [alias("EventRecordID")][nullable[int64]] $RecordID = $null,
         [int] $MaxRunspaces = [int]$env:NUMBER_OF_PROCESSORS + 1,
         [switch] $Oldest,
         [switch] $DisableParallel,
@@ -203,12 +203,20 @@ function Get-Events {
             Add-ToHashTable -Hashtable $EventFilter -Key "EndTime" -Value $EventEntry.DateTo
             Add-ToHashTable -Hashtable $EventFilter -Key "Keywords" -Value $ConvertedKeywords
             Add-ToHashTable -Hashtable $EventFilter -Key "Level" -Value $ConvertedLevels
-            Add-ToHashTable -Hashtable $EventFilter -Key "UserID" -Value $EventEntry.UserSID
+            $RequestedUserIDs = @(
+                foreach ($EventUserID in @($EventEntry.UserSID) + @($EventEntry.UserID)) {
+                    if (-not [String]::IsNullOrWhiteSpace([String] $EventUserID)) {
+                        $EventUserID
+                    }
+                }
+            )
+            Add-ToHashTable -Hashtable $EventFilter -Key "UserID" -Value $RequestedUserIDs
             Add-ToHashTable -Hashtable $EventFilter -Key "Data" -Value $EventEntry.Data
-            Add-ToHashTable -Hashtable $EventFilter -Key "RecordID" -Value $EventEntry.RecordID
+            if ([long] $EventEntry.RecordID -gt 0) {
+                Add-ToHashTable -Hashtable $EventFilter -Key "RecordID" -Value $EventEntry.RecordID
+            }
             Add-ToHashTable -Hashtable $EventFilter -Key "NamedDataFilter" -Value $EventEntry.NamedDataFilter
             Add-ToHashTable -Hashtable $EventFilter -Key "NamedDataExcludeFilter" -Value $EventEntry.NamedDataExcludeFilter
-            Add-ToHashTable -Hashtable $EventFilter -Key "UserID" -Value $EventEntry.UserID
             Add-ToHashTable -Hashtable $EventFilter -Key "ExcludeID" -Value $EventEntry.ExcludeID
 
             if ($Verbose) {
@@ -275,16 +283,24 @@ function Get-Events {
         [array] $ConvertedLevels = foreach ($DataLevel in $Level) {
             $LegacyLevelValues[[string] $DataLevel]
         }
+        $RequestedUserIDs = @(
+            foreach ($EventUserID in @($UserSID) + @($UserID)) {
+                if (-not [String]::IsNullOrWhiteSpace([String] $EventUserID)) {
+                    $EventUserID
+                }
+            }
+        )
         Add-ToHashTable -Hashtable $EventFilter -Key "Keywords" -Value $ConvertedKeywords
         Add-ToHashTable -Hashtable $EventFilter -Key "Level" -Value $ConvertedLevels
         Add-ToHashTable -Hashtable $EventFilter -Key "StartTime" -Value $DateFrom
         Add-ToHashTable -Hashtable $EventFilter -Key "EndTime" -Value $DateTo
-        Add-ToHashTable -Hashtable $EventFilter -Key "UserID" -Value $UserSID
+        Add-ToHashTable -Hashtable $EventFilter -Key "UserID" -Value $RequestedUserIDs
         Add-ToHashTable -Hashtable $EventFilter -Key "Data" -Value $Data
-        Add-ToHashTable -Hashtable $EventFilter -Key "RecordID" -Value $RecordID
+        if ($null -ne $RecordID -and $RecordID -gt 0) {
+            Add-ToHashTable -Hashtable $EventFilter -Key "RecordID" -Value $RecordID
+        }
         Add-ToHashTable -Hashtable $EventFilter -Key "NamedDataFilter" -Value $NamedDataFilter
         Add-ToHashTable -Hashtable $EventFilter -Key "NamedDataExcludeFilter" -Value $NamedDataExcludeFilter
-        Add-ToHashTable -Hashtable $EventFilter -Key "UserID" -Value $UserID
         Add-ToHashTable -Hashtable $EventFilter -Key "ExcludeID" -Value $ExcludeID
 
         [Array] $Param = foreach ($Comp in $Machine) {
@@ -340,7 +356,16 @@ function Get-Events {
     if ($DisableParallel) {
         Write-Verbose 'Get-Events - Running query with parallel disabled...'
         [Array] $AllEvents = foreach ($Parameter in $ParametersList) {
-            Invoke-Command -ScriptBlock $Script:ScriptBlock -ArgumentList $Parameter.Comp, $Parameter.Credential, $Parameter.EventFilter, $Parameter.MaxEvents, $Parameter.Oldest, $Parameter.Verbose
+            if ($ExtendedOutput) {
+                $DirectErrors = @()
+                [Array] $DirectOutput = @(Invoke-Command -ScriptBlock $Script:ScriptBlock -ArgumentList $Parameter.Comp, $Parameter.Credential, $Parameter.EventFilter, $Parameter.MaxEvents, $Parameter.Oldest, $Parameter.Verbose -ErrorAction SilentlyContinue -ErrorVariable +DirectErrors)
+                @{
+                    Output = $DirectOutput
+                    Errors = $DirectErrors
+                }
+            } else {
+                Invoke-Command -ScriptBlock $Script:ScriptBlock -ArgumentList $Parameter.Comp, $Parameter.Credential, $Parameter.EventFilter, $Parameter.MaxEvents, $Parameter.Oldest, $Parameter.Verbose
+            }
         }
     } else {
         Write-Verbose 'Get-Events - Running query with parallel enabled...'
@@ -349,6 +374,44 @@ function Get-Events {
             Start-Runspace -ScriptBlock $Script:ScriptBlock -Parameters $Parameter -RunspacePool $RunspacePool -Verbose:$Verbose
         }
         [Array] $AllEvents = Stop-Runspace -Runspaces $Runspaces -FunctionName "Get-Events" -RunspacePool $RunspacePool -Verbose:$Verbose -ErrorAction SilentlyContinue -ErrorVariable +AllErrors -ExtendedOutput:$ExtendedOutput
+    }
+    if ($ExtendedInput.Count -eq 0 -and $MaxEvents -gt 0) {
+        if ($ExtendedOutput) {
+            [Array] $EventCandidates = For ($ResultIndex = 0; $ResultIndex -lt $AllEvents.Count; $ResultIndex++) {
+                [Array] $ResultEvents = @($AllEvents[$ResultIndex].Output)
+                For ($EventIndex = 0; $EventIndex -lt $ResultEvents.Count; $EventIndex++) {
+                    [PSCustomObject] @{
+                        Key         = "$ResultIndex`:$EventIndex"
+                        TimeCreated = $ResultEvents[$EventIndex].TimeCreated
+                    }
+                }
+            }
+            [Array] $SelectedCandidates = if ($Oldest) {
+                @($EventCandidates | Sort-Object -Property TimeCreated | Select-Object -First $MaxEvents)
+            } else {
+                @($EventCandidates | Sort-Object -Property TimeCreated -Descending | Select-Object -First $MaxEvents)
+            }
+            $SelectedKeys = [System.Collections.Generic.HashSet[String]]::new([System.StringComparer]::Ordinal)
+            foreach ($Candidate in $SelectedCandidates) {
+                $null = $SelectedKeys.Add($Candidate.Key)
+            }
+            For ($ResultIndex = 0; $ResultIndex -lt $AllEvents.Count; $ResultIndex++) {
+                [Array] $ResultEvents = @($AllEvents[$ResultIndex].Output)
+                $AllEvents[$ResultIndex].Output = @(
+                    For ($EventIndex = 0; $EventIndex -lt $ResultEvents.Count; $EventIndex++) {
+                        if ($SelectedKeys.Contains("$ResultIndex`:$EventIndex")) {
+                            $ResultEvents[$EventIndex]
+                        }
+                    }
+                )
+            }
+        } elseif ($AllEvents.Count -gt $MaxEvents) {
+            if ($Oldest) {
+                [Array] $AllEvents = @($AllEvents | Sort-Object -Property TimeCreated | Select-Object -First $MaxEvents)
+            } else {
+                [Array] $AllEvents = @($AllEvents | Sort-Object -Property TimeCreated -Descending | Select-Object -First $MaxEvents)
+            }
+        }
     }
     Write-Verbose "Get-Events - Overall errors: $($AllErrors.Count)"
     Write-Verbose "Get-Events - Overall events processed in total for the report: $($AllEvents.Count)"

--- a/Private/Get-Events.ps1
+++ b/Private/Get-Events.ps1
@@ -179,10 +179,14 @@ function Get-Events {
 
     $MeasureTotal = [System.Diagnostics.Stopwatch]::StartNew() # Timer Start
     $ParametersList = [System.Collections.Generic.List[Object]]::new()
+    $ExtendedEntryQueryCounts = [System.Collections.Generic.List[Int]]::new()
+    $ExtendedEntryLimits = [System.Collections.Generic.List[Int]]::new()
 
     if ($ExtendedInput.Count -gt 0) {
         # Special input - PSWinReporting requires it
-        [Array] $Param = foreach ($EventEntry in $ExtendedInput) {
+        [Array] $Param = For ($ExtendedEntryIndex = 0; $ExtendedEntryIndex -lt $ExtendedInput.Count; $ExtendedEntryIndex++) {
+            $EventEntry = $ExtendedInput[$ExtendedEntryIndex]
+            [int] $EntryQueryCount = 0
             $EventFilter = @{ }
             if ($EventEntry.Type -eq 'File') {
                 Write-Verbose "Get-Events - Preparing data to scan file $($EventEntry.Server)"
@@ -244,6 +248,7 @@ function Get-Events {
                 }
                 $SplitArrayID = Split-Array -inArray $EventIds -size 22  # Support for more ID's then 22 (limitation of Get-WinEvent)
                 foreach ($EventIdGroup in $SplitArrayID) {
+                    $EntryQueryCount++
                     $EventFilter.Id = @($EventIdGroup)
                     @{
                         Comp        = $Comp
@@ -252,9 +257,11 @@ function Get-Events {
                         MaxEvents   = $EventEntry.MaxEvents
                         Oldest      = $Oldest
                         Verbose     = $Verbose
+                        EntryIndex  = $ExtendedEntryIndex
                     }
                 }
             } else {
+                $EntryQueryCount = 1
                 @{
                     Comp        = $Comp
                     Credential  = $Credential
@@ -262,8 +269,11 @@ function Get-Events {
                     MaxEvents   = $EventEntry.MaxEvents
                     Oldest      = $Oldest
                     Verbose     = $Verbose
+                    EntryIndex  = $ExtendedEntryIndex
                 }
             }
+            $null = $ExtendedEntryQueryCounts.Add($EntryQueryCount)
+            $null = $ExtendedEntryLimits.Add([int] $EventEntry.MaxEvents)
         }
         if ($null -ne $Param) {
             $null = $ParametersList.AddRange($Param)
@@ -334,6 +344,7 @@ function Get-Events {
                         MaxEvents   = $MaxEvents
                         Oldest      = $Oldest
                         Verbose     = $Verbose
+                        EntryIndex  = -1
                     }
                 }
             } else {
@@ -345,6 +356,7 @@ function Get-Events {
                     MaxEvents   = $MaxEvents
                     Oldest      = $Oldest
                     Verbose     = $Verbose
+                    EntryIndex  = -1
                 }
             }
         }
@@ -352,19 +364,29 @@ function Get-Events {
             $null = $ParametersList.AddRange($Param)
         }
     }
+    [bool] $NeedsExtendedEntryLimit = $false
+    For ($EntryIndex = 0; $EntryIndex -lt $ExtendedEntryQueryCounts.Count; $EntryIndex++) {
+        if ($ExtendedEntryQueryCounts[$EntryIndex] -gt 1 -and $ExtendedEntryLimits[$EntryIndex] -gt 0) {
+            $NeedsExtendedEntryLimit = $true
+            break
+        }
+    }
+    foreach ($Parameter in $ParametersList) {
+        $Parameter.IncludeEntryIndex = $NeedsExtendedEntryLimit
+    }
     $AllErrors = @()
     if ($DisableParallel) {
         Write-Verbose 'Get-Events - Running query with parallel disabled...'
         [Array] $AllEvents = foreach ($Parameter in $ParametersList) {
-            if ($ExtendedOutput) {
+            if ($ExtendedOutput -or $NeedsExtendedEntryLimit) {
                 $DirectErrors = @()
-                [Array] $DirectOutput = @(Invoke-Command -ScriptBlock $Script:ScriptBlock -ArgumentList $Parameter.Comp, $Parameter.Credential, $Parameter.EventFilter, $Parameter.MaxEvents, $Parameter.Oldest, $Parameter.Verbose -ErrorAction SilentlyContinue -ErrorVariable +DirectErrors)
+                [Array] $DirectOutput = @(Invoke-Command -ScriptBlock $Script:ScriptBlock -ArgumentList $Parameter.Comp, $Parameter.Credential, $Parameter.EventFilter, $Parameter.MaxEvents, $Parameter.Oldest, $Parameter.Verbose, $Parameter.EntryIndex, $Parameter.IncludeEntryIndex -ErrorAction SilentlyContinue -ErrorVariable +DirectErrors)
                 @{
                     Output = $DirectOutput
                     Errors = $DirectErrors
                 }
             } else {
-                Invoke-Command -ScriptBlock $Script:ScriptBlock -ArgumentList $Parameter.Comp, $Parameter.Credential, $Parameter.EventFilter, $Parameter.MaxEvents, $Parameter.Oldest, $Parameter.Verbose
+                Invoke-Command -ScriptBlock $Script:ScriptBlock -ArgumentList $Parameter.Comp, $Parameter.Credential, $Parameter.EventFilter, $Parameter.MaxEvents, $Parameter.Oldest, $Parameter.Verbose, $Parameter.EntryIndex, $Parameter.IncludeEntryIndex
             }
         }
     } else {
@@ -373,7 +395,65 @@ function Get-Events {
         $Runspaces = foreach ($Parameter in $ParametersList) {
             Start-Runspace -ScriptBlock $Script:ScriptBlock -Parameters $Parameter -RunspacePool $RunspacePool -Verbose:$Verbose
         }
-        [Array] $AllEvents = Stop-Runspace -Runspaces $Runspaces -FunctionName "Get-Events" -RunspacePool $RunspacePool -Verbose:$Verbose -ErrorAction SilentlyContinue -ErrorVariable +AllErrors -ExtendedOutput:$ExtendedOutput
+        [Array] $AllEvents = Stop-Runspace -Runspaces $Runspaces -FunctionName "Get-Events" -RunspacePool $RunspacePool -Verbose:$Verbose -ErrorAction SilentlyContinue -ErrorVariable +AllErrors -ExtendedOutput:($ExtendedOutput -or $NeedsExtendedEntryLimit)
+    }
+    if ($NeedsExtendedEntryLimit) {
+        $SelectedEntryKeys = [System.Collections.Generic.HashSet[String]]::new([System.StringComparer]::Ordinal)
+        $LimitedEntryIndexes = [System.Collections.Generic.HashSet[Int]]::new()
+        For ($EntryIndex = 0; $EntryIndex -lt $ExtendedEntryQueryCounts.Count; $EntryIndex++) {
+            [int] $EntryQueryCount = $ExtendedEntryQueryCounts[$EntryIndex]
+            [int] $EntryLimit = $ExtendedEntryLimits[$EntryIndex]
+            if ($EntryQueryCount -gt 1 -and $EntryLimit -gt 0) {
+                $null = $LimitedEntryIndexes.Add($EntryIndex)
+                [Array] $EntryCandidates = For ($ResultIndex = 0; $ResultIndex -lt $AllEvents.Count; $ResultIndex++) {
+                    [Array] $ResultEvents = @($AllEvents[$ResultIndex].Output)
+                    For ($EventIndex = 0; $EventIndex -lt $ResultEvents.Count; $EventIndex++) {
+                        if ($ResultEvents[$EventIndex].EntryIndex -eq $EntryIndex) {
+                            [PSCustomObject] @{
+                                Key         = "$ResultIndex`:$EventIndex"
+                                TimeCreated = $ResultEvents[$EventIndex].Event.TimeCreated
+                            }
+                        }
+                    }
+                }
+                [Array] $SelectedCandidates = if ($Oldest) {
+                    @($EntryCandidates | Sort-Object -Property TimeCreated | Select-Object -First $EntryLimit)
+                } else {
+                    @($EntryCandidates | Sort-Object -Property TimeCreated -Descending | Select-Object -First $EntryLimit)
+                }
+                foreach ($Candidate in $SelectedCandidates) {
+                    $null = $SelectedEntryKeys.Add($Candidate.Key)
+                }
+            }
+        }
+        For ($ResultIndex = 0; $ResultIndex -lt $AllEvents.Count; $ResultIndex++) {
+            [Array] $ResultEvents = @($AllEvents[$ResultIndex].Output)
+            $AllEvents[$ResultIndex].Output = @(
+                For ($EventIndex = 0; $EventIndex -lt $ResultEvents.Count; $EventIndex++) {
+                    if (-not $LimitedEntryIndexes.Contains([int] $ResultEvents[$EventIndex].EntryIndex) -or $SelectedEntryKeys.Contains("$ResultIndex`:$EventIndex")) {
+                        $ResultEvents[$EventIndex].Event
+                    }
+                }
+            )
+        }
+        if (-not $ExtendedOutput) {
+            [Array] $ExtendedLimitErrors = foreach ($QueryResult in $AllEvents) {
+                foreach ($QueryError in @($QueryResult.Errors)) {
+                    $QueryError
+                    if ($QueryError -is [System.Management.Automation.ErrorRecord]) {
+                        Write-Error -ErrorRecord $QueryError
+                    } else {
+                        Write-Error -Message ([String] $QueryError)
+                    }
+                }
+            }
+            $AllErrors = @($AllErrors) + @($ExtendedLimitErrors)
+            [Array] $AllEvents = @(
+                foreach ($QueryResult in $AllEvents) {
+                    $QueryResult.Output
+                }
+            )
+        }
     }
     if ($ExtendedInput.Count -eq 0 -and $MaxEvents -gt 0) {
         if ($ExtendedOutput) {

--- a/Private/Logging/Get-Logger.ps1
+++ b/Private/Logging/Get-Logger.ps1
@@ -66,8 +66,10 @@ function Get-Logger {
 
     if ($LogPath) {
         $LogsDir = [System.IO.Path]::GetDirectoryName($LogPath)
-        New-Item $LogsDir -ItemType Directory -Force | Out-Null
-        New-Item $LogPath -ItemType File -Force | Out-Null
+        if (-not [String]::IsNullOrWhiteSpace($LogsDir)) {
+            New-Item -Path $LogsDir -ItemType Directory -Force | Out-Null
+        }
+        New-Item -Path $LogPath -ItemType File -Force | Out-Null
     }
 
     $Logger = [PSCustomObject]@{

--- a/Private/Logging/Get-Logger.ps1
+++ b/Private/Logging/Get-Logger.ps1
@@ -82,9 +82,9 @@ function Get-Logger {
             [string]$String
         )
         if (-not $this.LogPath) {
-            Write-Color -Text "[Error] ", $String -Color Red, White -ShowTime:$this.ShowTime -TimeFormat $this:TimeFormat
+            Write-Color -Text "[Error] ", $String -Color Red, White -ShowTime:$this.ShowTime -TimeFormat $this.TimeFormat
         } else {
-            Write-Color -Text "[Error] ", $String -Color Red, White -LogFile:$this.LogPath -ShowTime:$this.ShowTime -TimeFormat $this:TimeFormat
+            Write-Color -Text "[Error] ", $String -Color Red, White -LogFile:$this.LogPath -ShowTime:$this.ShowTime -TimeFormat $this.TimeFormat
         }
     }
 
@@ -94,9 +94,9 @@ function Get-Logger {
             [string]$String
         )
         if (-not $this.LogPath) {
-            Write-Color -Text "[Info] ", $String -Color Yellow, White -ShowTime:$this.ShowTime -TimeFormat $this:TimeFormat
+            Write-Color -Text "[Info] ", $String -Color Yellow, White -ShowTime:$this.ShowTime -TimeFormat $this.TimeFormat
         } else {
-            Write-Color -Text "[Info] ", $String -Color Yellow, White -LogFile:$this.LogPath -ShowTime:$this.ShowTime -TimeFormat $this:TimeFormat
+            Write-Color -Text "[Info] ", $String -Color Yellow, White -LogFile:$this.LogPath -ShowTime:$this.ShowTime -TimeFormat $this.TimeFormat
         }
     }
 
@@ -106,9 +106,9 @@ function Get-Logger {
             [string]$String
         )
         if (-not $this.LogPath) {
-            Write-Color -Text "[Warning] ", $String -Color Magenta, White -ShowTime:$this.ShowTime -TimeFormat $this:TimeFormat
+            Write-Color -Text "[Warning] ", $String -Color Magenta, White -ShowTime:$this.ShowTime -TimeFormat $this.TimeFormat
         } else {
-            Write-Color -Text "[Warning] ", $String -Color Magenta, White -LogFile:$this.LogPath -ShowTime:$this.ShowTime -TimeFormat $this:TimeFormat
+            Write-Color -Text "[Warning] ", $String -Color Magenta, White -LogFile:$this.LogPath -ShowTime:$this.ShowTime -TimeFormat $this.TimeFormat
         }
     }
 
@@ -118,9 +118,9 @@ function Get-Logger {
             [string]$String
         )
         if (-not $this.LogPath) {
-            Write-Color -Text " $String" -Color White -ShowTime:$this.ShowTime -TimeFormat $this:TimeFormat
+            Write-Color -Text " $String" -Color White -ShowTime:$this.ShowTime -TimeFormat $this.TimeFormat
         } else {
-            Write-Color -Text " $String" -Color White -LogFile:$this.LogPath -ShowTime:$this.ShowTime -TimeFormat $this:TimeFormat
+            Write-Color -Text " $String" -Color White -LogFile:$this.LogPath -ShowTime:$this.ShowTime -TimeFormat $this.TimeFormat
         }
     }
     Add-Member -InputObject $Logger -MemberType ScriptMethod AddSuccessRecord -Value {
@@ -129,9 +129,9 @@ function Get-Logger {
             [string]$String
         )
         if (-not $this.LogPath) {
-            Write-Color -Text "[Success] ", $String -Color Green, White -ShowTime:$this.ShowTime -TimeFormat $this:TimeFormat
+            Write-Color -Text "[Success] ", $String -Color Green, White -ShowTime:$this.ShowTime -TimeFormat $this.TimeFormat
         } else {
-            Write-Color -Text "[Success] ", $String -Color Green, White -LogFile:$this.LogPath -ShowTime:$this.ShowTime -TimeFormat $this:TimeFormat
+            Write-Color -Text "[Success] ", $String -Color Green, White -LogFile:$this.LogPath -ShowTime:$this.ShowTime -TimeFormat $this.TimeFormat
         }
     }
     return $Logger

--- a/Private/Objects/Add-ToHashTable.ps1
+++ b/Private/Objects/Add-ToHashTable.ps1
@@ -25,7 +25,9 @@ function Add-ToHashTable($Hashtable, $Key, $Value) {
     Add-ToHashTable -Hashtable $myHashtable -Key "Age" -Value 25
     # Adds the key-value pair "Age"-25 to $myHashtable.
     #>
-    if ($null -ne $Value -and $Value -ne '') {
+    if ($null -ne $Value -and
+        -not ($Value -is [string] -and $Value.Length -eq 0) -and
+        -not ($Value -is [System.Collections.ICollection] -and $Value.Count -eq 0)) {
         $Hashtable.Add($Key, $Value)
     }
 }

--- a/Private/PSWinReportingDateTime.ps1
+++ b/Private/PSWinReportingDateTime.ps1
@@ -1,11 +1,14 @@
 function Find-DatesQuarterLast ([bool] $Force) {
     #https://blogs.technet.microsoft.com/dsheehan/2017/09/21/use-powershell-to-determine-the-first-day-of-the-current-calendar-quarter/
-    $Today = (Get-Date).AddDays(-90)
-    $Yesterday = ((Get-Date).AddDays(-1))
-    $Quarter = [Math]::Ceiling($Today.Month / 3)
-    $LastDay = [DateTime]::DaysInMonth([Int]$Today.Year.ToString(), [Int]($Quarter * 3))
-    $StartDate = (get-date -Year $Today.Year -Month ($Quarter * 3 - 2) -Day 1).Date
-    $EndDate = (get-date -Year $Today.Year -Month ($Quarter * 3) -Day $LastDay).Date.AddDays(1).AddTicks(-1)
+    $Today = Get-Date
+    $Yesterday = $Today.AddDays(-1)
+    $CurrentQuarter = [Math]::Ceiling($Today.Month / 3)
+    $CurrentQuarterStart = (Get-Date -Year $Today.Year -Month ($CurrentQuarter * 3 - 2) -Day 1).Date
+    $PreviousQuarterDate = $CurrentQuarterStart.AddDays(-1)
+    $Quarter = [Math]::Ceiling($PreviousQuarterDate.Month / 3)
+    $LastDay = [DateTime]::DaysInMonth($PreviousQuarterDate.Year, [Int]($Quarter * 3))
+    $StartDate = (Get-Date -Year $PreviousQuarterDate.Year -Month ($Quarter * 3 - 2) -Day 1).Date
+    $EndDate = (Get-Date -Year $PreviousQuarterDate.Year -Month ($Quarter * 3) -Day $LastDay).Date.AddDays(1).AddTicks(-1)
 
     if ($Force -eq $true -or $Yesterday.Date -eq $EndDate.Date) {
         $DateParameters = @{

--- a/Private/Request-Credential.ps1
+++ b/Private/Request-Credential.ps1
@@ -1,0 +1,128 @@
+function Request-Credentials {
+    <#
+    .SYNOPSIS
+    Requests credentials for authentication purposes.
+
+    .DESCRIPTION
+    The Request-Credentials function is used to prompt the user for credentials. It provides options to input the username and password directly, read the password from a file, convert the password to a secure string, and handle various error scenarios.
+
+    .PARAMETER UserName
+    Specifies the username for authentication.
+
+    .PARAMETER Password
+    Specifies the password for authentication.
+
+    .PARAMETER AsSecure
+    Indicates whether the password should be converted to a secure string.
+
+    .PARAMETER FromFile
+    Specifies whether the password should be read from a file.
+
+    .PARAMETER Output
+    Indicates whether the function should return output in case of errors.
+
+    .PARAMETER NetworkCredentials
+    Specifies if network credentials are being requested.
+
+    .PARAMETER Service
+    Specifies the service for which credentials are being requested.
+
+    .EXAMPLE
+    Request-Credentials -UserName 'JohnDoe' -Password 'P@ssw0rd' -AsSecure
+    Requests credentials for the user 'JohnDoe' with the password 'P@ssw0rd' in a secure format.
+
+    .EXAMPLE
+    Request-Credentials -FromFile -Password 'C:\Credentials.txt' -Output -Service 'FTP'
+    Reads the password from the file 'C:\Credentials.txt' and returns an error message if the file is unreadable for the FTP service.
+
+    #>
+    [CmdletBinding()]
+    param(
+        [string] $UserName,
+        [string] $Password,
+        [switch] $AsSecure,
+        [switch] $FromFile,
+        [switch] $Output,
+        [switch] $NetworkCredentials,
+        [string] $Service
+    )
+    if ($FromFile) {
+        if (($Password -ne '') -and (Test-Path $Password)) {
+            # File is there and we are reading it into Password
+            Write-Verbose "Request-Credentials - Reading password from file $Password"
+            $Password = Get-Content -Path $Password
+        } else {
+            # File is not there or couldn't be read
+            if ($Output) {
+                return @{ Status = $false; Output = $Service; Extended = 'File with password unreadable.' }
+            } else {
+                Write-Warning "Request-Credentials - Secure password from file couldn't be read. File not readable. Terminating."
+                return
+            }
+        }
+    }
+    if ($AsSecure) {
+        try {
+            $NewPassword = $Password | ConvertTo-SecureString -ErrorAction Stop
+        } catch {
+            $ErrorMessage = $_.Exception.Message -replace "`n", " " -replace "`r", " "
+            if ($ErrorMessage -like '*Key not valid for use in specified state*') {
+                if ($Output) {
+                    return @{ Status = $false; Output = $Service; Extended = "Couldn't use credentials provided. Most likely using credentials from other user/session/computer." }
+                } else {
+                    Write-Warning -Message "Request-Credentials - Couldn't use credentials provided. Most likely using credentials from other user/session/computer."
+                    return
+                }
+            } else {
+                if ($Output) {
+                    return @{ Status = $false; Output = $Service; Extended = $ErrorMessage }
+                } else {
+                    Write-Warning -Message "Request-Credentials - $ErrorMessage"
+                    return
+                }
+            }
+        }
+
+    } else {
+        $NewPassword = $Password
+    }
+    if ($UserName -and $NewPassword) {
+        if ($AsSecure) {
+            $Credentials = New-Object System.Management.Automation.PSCredential($Username, $NewPassword)
+        } else {
+            Try {
+                $SecurePassword = $Password | ConvertTo-SecureString -asPlainText -Force -ErrorAction Stop
+            } catch {
+                $ErrorMessage = $_.Exception.Message -replace "`n", " " -replace "`r", " "
+                if ($ErrorMessage -like '*Key not valid for use in specified state*') {
+                    if ($Output) {
+                        return  @{ Status = $false; Output = $Service; Extended = "Couldn't use credentials provided. Most likely using credentials from other user/session/computer." }
+                    } else {
+                        Write-Warning -Message "Request-Credentials - Couldn't use credentials provided. Most likely using credentials from other user/session/computer."
+                        return
+                    }
+                } else {
+                    if ($Output) {
+                        return @{ Status = $false; Output = $Service; Extended = $ErrorMessage }
+                    } else {
+                        Write-Warning -Message "Request-Credentials - $ErrorMessage"
+                        return
+                    }
+                }
+            }
+            $Credentials = New-Object System.Management.Automation.PSCredential($Username, $SecurePassword)
+        }
+    } else {
+        if ($Output) {
+            return @{ Status = $false; Output = $Service; Extended = 'Username or/and Password is empty' }
+        } else {
+            Write-Warning -Message 'Request-Credentials - UserName or Password are empty.'
+            return
+        }
+    }
+    if ($NetworkCredentials) {
+        return $Credentials.GetNetworkCredential()
+    } else {
+        return $Credentials
+    }
+}

--- a/Private/SQL/Get-SqlQueryColumnInformation.ps1
+++ b/Private/SQL/Get-SqlQueryColumnInformation.ps1
@@ -35,7 +35,7 @@ function Get-SqlQueryColumnInformation {
             Invoke-DbaQuery -ErrorAction Stop -SqlInstance $SqlServer -Query $Query #-Verbose
         } catch {
             $ErrorMessage = $_.Exception.Message -replace "`n", " " -replace "`r", " "
-            "Error occured (Get-SqlQueryColumnInformation): $ErrorMessage" # return of error
+            throw "Get-SqlQueryColumnInformation failed: $ErrorMessage"
         }
     )
     return $SQLReturn

--- a/Private/ScriptBlock.ps1
+++ b/Private/ScriptBlock.ps1
@@ -635,6 +635,9 @@ $Script:ScriptBlock = {
             }
             return [System.Net.WebUtility]::HtmlDecode([String] $Filter)
         } else {
+            if (-not $filter) {
+                $filter = '*'
+            }
             if ($Path -ne '') {
                 $EscapedPath = [System.Security.SecurityElement]::Escape("file://$Path")
                 $FilterXML = @"
@@ -674,6 +677,73 @@ $Script:ScriptBlock = {
             [int]$MaxEvents,
             [switch] $Oldest
         )
+
+        function Test-XPathLiteralRequiresPostFilter {
+            param (
+                [AllowNull()]
+                [Object] $Value
+            )
+
+            [String] $Text = [String] $Value
+            $Text.Contains("'") -and $Text.Contains('"')
+        }
+
+        function Test-NamedDataRequiresPostFilter {
+            param (
+                [Array] $Filters
+            )
+
+            ForEach ($NamedDataEntry in @($Filters)) {
+                ForEach ($Key in $NamedDataEntry.Keys) {
+                    if (Test-XPathLiteralRequiresPostFilter -Value $Key) {
+                        return $true
+                    }
+                    ForEach ($Value in @($NamedDataEntry[$Key])) {
+                        if (Test-XPathLiteralRequiresPostFilter -Value $Value) {
+                            return $true
+                        }
+                    }
+                }
+            }
+            $false
+        }
+
+        function Test-NamedDataMatch {
+            param (
+                [xml] $EventXml,
+                [System.Collections.IDictionary] $Filter
+            )
+
+            ForEach ($Key in $Filter.Keys) {
+                [Array] $DataNodes = ForEach ($CandidateDataNode in @($EventXml.Event.EventData.Data)) {
+                    if ([String] $CandidateDataNode.Name -ceq [String] $Key) {
+                        $CandidateDataNode
+                    }
+                }
+                [Array] $ExpectedValues = @($Filter[$Key])
+                if ($ExpectedValues.Count -eq 0 -or ($Filter[$Key] -is [String] -and $Filter[$Key].Length -eq 0)) {
+                    [bool] $KeyMatches = $DataNodes.Count -gt 0
+                } else {
+                    [bool] $KeyMatches = $false
+                    ForEach ($DataNode in $DataNodes) {
+                        ForEach ($ExpectedValue in $ExpectedValues) {
+                            if ([String] $DataNode.InnerText -ceq [String] $ExpectedValue) {
+                                $KeyMatches = $true
+                                break
+                            }
+                        }
+                        if ($KeyMatches) {
+                            break
+                        }
+                    }
+                }
+                if (-not $KeyMatches) {
+                    return $false
+                }
+            }
+            $true
+        }
+
         $Measure = [System.Diagnostics.Stopwatch]::StartNew() # Timer Start
 
         Write-Verbose "Get-Events - Inside $Comp for Events ID: $($EventFilter.ID)"
@@ -683,7 +753,11 @@ $Script:ScriptBlock = {
         try {
             [Array] $Events = @(
                 [bool] $PostFilterProvider = $false
+                [Array] $PostDataValues = @()
+                [Array] $PostNamedDataInclusions = @()
                 [Array] $PostNamedDataExclusions = @()
+                [Array] $PostIncludeIDs = @()
+                [Array] $PostExcludeIDs = @()
                 [bool] $IsPathQuery = $null -ne $EventFilter.Path
                 [bool] $IsProviderQuery = -not $IsPathQuery -and $null -eq $EventFilter.LogName -and $null -ne $EventFilter.ProviderName
                 [bool] $IsLogWildcardQuery = $false
@@ -703,10 +777,15 @@ $Script:ScriptBlock = {
                         $IsPathQuery
                 ) {
                     $FilterForQuery = $EventFilter.Clone()
+                    if ($FilterForQuery.ID) {
+                        [Array] $PostIncludeIDs = @($FilterForQuery.ID | Sort-Object -Unique)
+                        $FilterForQuery.Remove('ID')
+                    }
                     if ($FilterForQuery.ProviderName) {
                         [Array] $ProviderPatterns = @($FilterForQuery.ProviderName)
                         ForEach ($ProviderPattern in $ProviderPatterns) {
-                            if ([System.Management.Automation.WildcardPattern]::ContainsWildcardCharacters([String] $ProviderPattern)) {
+                            if ([System.Management.Automation.WildcardPattern]::ContainsWildcardCharacters([String] $ProviderPattern) -or
+                                (Test-XPathLiteralRequiresPostFilter -Value $ProviderPattern)) {
                                 $PostFilterProvider = -not $IsProviderQuery
                                 break
                             }
@@ -715,14 +794,39 @@ $Script:ScriptBlock = {
                             $FilterForQuery.Remove('ProviderName')
                         }
                     }
+                    if ($FilterForQuery.Data) {
+                        ForEach ($DataValue in @($FilterForQuery.Data)) {
+                            if (Test-XPathLiteralRequiresPostFilter -Value $DataValue) {
+                                [Array] $PostDataValues = @($FilterForQuery.Data)
+                                $FilterForQuery.Remove('Data')
+                                break
+                            }
+                        }
+                    }
+                    if ($FilterForQuery.NamedDataFilter -and
+                        (Test-NamedDataRequiresPostFilter -Filters @($FilterForQuery.NamedDataFilter))) {
+                        [Array] $PostNamedDataInclusions = @($FilterForQuery.NamedDataFilter)
+                        $FilterForQuery.Remove('NamedDataFilter')
+                    }
+                    if ($FilterForQuery.ExcludeID) {
+                        [Array] $PostExcludeIDs = @($FilterForQuery.ExcludeID | Sort-Object -Unique)
+                        $FilterForQuery.Remove('ExcludeID')
+                    }
                     if ($IsLogWildcardQuery) {
                         $FilterForQuery.Remove('LogName')
                     }
+                    if ($FilterForQuery.NamedDataExcludeFilter -and
+                        ($IsPathQuery -or $IsProviderQuery -or $IsLogWildcardQuery -or
+                            (Test-NamedDataRequiresPostFilter -Filters @($FilterForQuery.NamedDataExcludeFilter)))) {
+                        [Array] $PostNamedDataExclusions = @($FilterForQuery.NamedDataExcludeFilter)
+                        $FilterForQuery.Remove('NamedDataExcludeFilter')
+                    }
+                    [bool] $HasCustomFilter = $null -ne $FilterForQuery.RecordID -or
+                        $null -ne $FilterForQuery.NamedDataFilter -or
+                        $null -ne $FilterForQuery.ExcludeID -or
+                        $null -ne $FilterForQuery.NamedDataExcludeFilter -or
+                        $null -ne $FilterForQuery.UserID
                     if ($IsPathQuery -or $IsProviderQuery -or $IsLogWildcardQuery) {
-                        if ($FilterForQuery.NamedDataExcludeFilter) {
-                            [Array] $PostNamedDataExclusions = @($FilterForQuery.NamedDataExcludeFilter)
-                            $FilterForQuery.Remove('NamedDataExcludeFilter')
-                        }
                         $FilterXPath = Get-EventsFilter @FilterForQuery -XPathOnly
                         if (-not $FilterXPath) {
                             $FilterXPath = '*'
@@ -744,7 +848,7 @@ $Script:ScriptBlock = {
                             $SplatEvents.ComputerName = $Comp
                             Write-Verbose "Get-Events - Inside $Comp - Custom FilterXPath for wildcard log: `n$FilterXPath"
                         }
-                    } else {
+                    } elseif ($HasCustomFilter) {
                         $FilterXML = Get-EventsFilter @FilterForQuery
                         $SplatEvents = @{
                             ErrorAction  = 'Stop'
@@ -753,6 +857,13 @@ $Script:ScriptBlock = {
                             FilterXml    = $FilterXML
                         }
                         Write-Verbose "Get-Events - Inside $Comp - Custom FilterXML: `n$FilterXML"
+                    } else {
+                        $SplatEvents = @{
+                            ErrorAction     = 'Stop'
+                            ComputerName    = $Comp
+                            Oldest          = $Oldest
+                            FilterHashtable = $FilterForQuery
+                        }
                     }
                 } else {
                     $SplatEvents = @{
@@ -765,7 +876,13 @@ $Script:ScriptBlock = {
                         Write-Verbose "Get-Events - Inside $Comp Data in FilterHashTable $k $($EventFilter[$k])"
                     }
                 }
-                if ($MaxEvents -ne 0 -and -not $PostFilterProvider -and $PostNamedDataExclusions.Count -eq 0) {
+                [bool] $NeedsPostFilter = $PostFilterProvider -or
+                    $PostDataValues.Count -gt 0 -or
+                    $PostNamedDataInclusions.Count -gt 0 -or
+                    $PostNamedDataExclusions.Count -gt 0 -or
+                    $PostIncludeIDs.Count -gt 0 -or
+                    $PostExcludeIDs.Count -gt 0
+                if ($MaxEvents -ne 0 -and -not $NeedsPostFilter) {
                     $SplatEvents.MaxEvents = $MaxEvents
                     Write-Verbose "Get-Events - Inside $Comp for Events Max Events: $MaxEvents"
                 }
@@ -773,9 +890,9 @@ $Script:ScriptBlock = {
                     $SplatEvents.Credential = $Credential
                     Write-Verbose "Get-Events - Inside $Comp for Events Credential: $Credential"
                 }
-                [Array] $QueriedEvents = @(Get-WinEvent @SplatEvents)
-                if ($PostFilterProvider -or $PostNamedDataExclusions.Count -gt 0) {
-                    [Array] $PostFilteredEvents = ForEach ($QueriedEvent in $QueriedEvents) {
+                if ($NeedsPostFilter) {
+                    $PostFilterScript = {
+                        $QueriedEvent = $_
                         [bool] $ProviderMatched = -not $PostFilterProvider
                         if ($PostFilterProvider) {
                             ForEach ($ProviderPattern in $ProviderPatterns) {
@@ -785,56 +902,59 @@ $Script:ScriptBlock = {
                                 }
                             }
                         }
-                        [bool] $Excluded = $false
-                        if ($ProviderMatched -and $PostNamedDataExclusions.Count -gt 0) {
-                            [xml] $QueriedEventXml = $QueriedEvent.ToXml()
-                            ForEach ($Exclusion in $PostNamedDataExclusions) {
-                                [bool] $AllKeysMatch = $true
-                                ForEach ($Key in $Exclusion.Keys) {
-                                    [Array] $DataNodes = ForEach ($CandidateDataNode in @($QueriedEventXml.Event.EventData.Data)) {
-                                        if ($CandidateDataNode.Name -eq [String] $Key) {
-                                            $CandidateDataNode
-                                        }
-                                    }
-                                    [Array] $ExpectedValues = @($Exclusion[$Key])
-                                    if ($ExpectedValues.Count -eq 0 -or ($Exclusion[$Key] -is [String] -and $Exclusion[$Key].Length -eq 0)) {
-                                        [bool] $KeyMatches = $DataNodes.Count -gt 0
-                                    } else {
-                                        [bool] $KeyMatches = $false
-                                        ForEach ($DataNode in $DataNodes) {
-                                            ForEach ($ExpectedValue in $ExpectedValues) {
-                                                if ([String] $DataNode.'#text' -ceq [String] $ExpectedValue) {
-                                                    $KeyMatches = $true
-                                                    break
-                                                }
-                                            }
-                                            if ($KeyMatches) {
-                                                break
-                                            }
-                                        }
-                                    }
-                                    if (-not $KeyMatches) {
-                                        $AllKeysMatch = $false
+                        [bool] $EventIDMatched = ($PostIncludeIDs.Count -eq 0 -or $PostIncludeIDs -contains $QueriedEvent.Id) -and
+                            ($PostExcludeIDs.Count -eq 0 -or $PostExcludeIDs -notcontains $QueriedEvent.Id)
+                        [bool] $RequiresEventXml = $PostDataValues.Count -gt 0 -or
+                            $PostNamedDataInclusions.Count -gt 0 -or
+                            $PostNamedDataExclusions.Count -gt 0
+                        [xml] $QueriedEventXml = $null
+                        if ($ProviderMatched -and $EventIDMatched -and $RequiresEventXml) {
+                            $QueriedEventXml = $QueriedEvent.ToXml()
+                        }
+                        [bool] $DataMatched = $PostDataValues.Count -eq 0
+                        if ($ProviderMatched -and $EventIDMatched -and $PostDataValues.Count -gt 0) {
+                            ForEach ($DataNode in @($QueriedEventXml.Event.EventData.Data)) {
+                                ForEach ($ExpectedDataValue in $PostDataValues) {
+                                    if ([String] $DataNode.InnerText -ceq [String] $ExpectedDataValue) {
+                                        $DataMatched = $true
                                         break
                                     }
                                 }
-                                if ($AllKeysMatch) {
+                                if ($DataMatched) {
+                                    break
+                                }
+                            }
+                        }
+                        [bool] $NamedDataIncluded = $PostNamedDataInclusions.Count -eq 0
+                        if ($ProviderMatched -and $EventIDMatched -and $DataMatched -and $PostNamedDataInclusions.Count -gt 0) {
+                            ForEach ($Inclusion in $PostNamedDataInclusions) {
+                                if (Test-NamedDataMatch -EventXml $QueriedEventXml -Filter $Inclusion) {
+                                    $NamedDataIncluded = $true
+                                    break
+                                }
+                            }
+                        }
+                        [bool] $Excluded = $false
+                        if ($ProviderMatched -and $EventIDMatched -and $DataMatched -and $NamedDataIncluded -and
+                            $PostNamedDataExclusions.Count -gt 0) {
+                            ForEach ($Exclusion in $PostNamedDataExclusions) {
+                                if (Test-NamedDataMatch -EventXml $QueriedEventXml -Filter $Exclusion) {
                                     $Excluded = $true
                                     break
                                 }
                             }
                         }
-                        if ($ProviderMatched -and -not $Excluded) {
+                        if ($ProviderMatched -and $EventIDMatched -and $DataMatched -and $NamedDataIncluded -and -not $Excluded) {
                             $QueriedEvent
                         }
                     }
                     if ($MaxEvents -ne 0) {
-                        $PostFilteredEvents | Select-Object -First $MaxEvents
+                        Get-WinEvent @SplatEvents | ForEach-Object -Process $PostFilterScript | Select-Object -First $MaxEvents
                     } else {
-                        $PostFilteredEvents
+                        Get-WinEvent @SplatEvents | ForEach-Object -Process $PostFilterScript
                     }
                 } else {
-                    $QueriedEvents
+                    Get-WinEvent @SplatEvents
                 }
             )
             #$EventsCount = ($Events | Measure-Object).Count

--- a/Private/ScriptBlock.ps1
+++ b/Private/ScriptBlock.ps1
@@ -1,0 +1,854 @@
+$Script:ScriptBlock = {
+    Param (
+        [string]$Comp,
+        [ValidateNotNull()]
+        [alias('Credentials')][System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]$Credential = [System.Management.Automation.PSCredential]::Empty,
+        [hashtable]$EventFilter,
+        [int]$MaxEvents,
+        [bool] $Oldest,
+        [bool] $Verbose
+    )
+    if ($Verbose) {
+        $VerbosePreference = 'continue'
+    }
+    function Get-EventsFilter {
+        <#
+        .SYNOPSIS
+        This function generates an xpath filter that can be used with the -FilterXPath
+        parameter of Get-WinEvent.  It may also be used inside the <Select></Select tags
+        of a Custom View in Event Viewer.
+        .DESCRIPTION
+        This function generates an xpath filter that can be used with the -FilterXPath
+        parameter of Get-WinEvent.  It may also be used inside the <Select></Select tags
+        of a Custom View in Event Viewer.
+
+        This function allows for the create of xpath which can select events based on
+        many properties of the event including those of named data nodes in the event's
+        XML.
+
+        XPath is case sensetive and the data passed to the parameters here must
+        match the case of the data in the event's XML.
+        .NOTES
+        Original Code by https://community.spiceworks.com/scripts/show/3238-powershell-xpath-generator-for-windows-events
+        Extended by Justin Grote
+        Extended by Przemyslaw Klys
+        .LINK
+
+        .PARAMETER ID
+        This parameter accepts and array of event ids to include in the xpath filter.
+        .PARAMETER StartTime
+        This parameter sets the oldest event that may be returned by the xpath.
+
+        Please, note that the xpath time selector created here is based of of the
+        time the xpath is generated.  XPath uses a time difference method to select
+        events by time; that time difference being the number of milliseconds between
+        the time and now.
+        .PARAMETER EndTime
+        This parameter sets the newest event that may be returned by the xpath.
+
+        Please, note that the xpath time selector created here is based of of the
+        time the xpath is generated.  XPath uses a time difference method to select
+        events by time; that time difference being the number of milliseconds between
+        the time and now.
+        .PARAMETER Data
+        This parameter will accept an array of values that may be found in the data
+        section of the event's XML.
+        .PARAMETER ProviderName
+        This parameter will accept an array of values that select events from event
+        providers.
+        .PARAMETER Level
+        This parameter will accept an array of values that specify the severity
+        rating of the events to be returned.
+
+        It accepts the following values.
+
+        'Critical',
+        'Error',
+        'Informational',
+        'LogAlways',
+        'Verbose',
+        'Warning'
+        .PARAMETER Keywords
+        This parameter accepts and array of long integer keywords. You must
+        pass this parameter the long integer value of the keywords you want
+        to search and not the keyword description.
+        .PARAMETER UserID
+        This parameter will accept an array of SIDs or domain accounts.
+        .PARAMETER NamedDataFilter
+        This parameter will accept and array of hashtables that define the key
+        value pairs for which you want to filter against the event's named data
+        fields.
+
+        Key values, as with XPath filters, are case sensetive.
+
+        You may assign an array as the value of any key. This will search
+        for events where any of the values are present in that particular
+        data field. If you wanted to define a filter that searches for a SubjectUserName
+        of either john.doe or jane.doe, pass the following
+
+        @{'SubjectUserName'=('john.doe','jane.doe')}
+
+        You may specify multiple data files and values. Doing so will create
+        an XPath filter that will only return results where both values
+        are found. If you only wanted to return events where both the
+        SubjectUserName is john.doe and the TargetUserName is jane.doe, then
+        pass the following
+
+        @{'SubjectUserName'='john.doe';'TargetUserName'='jane.doe'}
+
+        You may pass an array of hash tables to create an 'or' XPath filter
+        that will return objects where either key value set will be returned.
+        If you wanted to define a filter that searches for either a
+        SubjectUserName of john.doe or a TargetUserName of jane.doe then pass
+        the following
+
+        (@{'SubjectUserName'='john.doe'},@{'TargetUserName'='jane.doe'})
+        .EXAMPLE
+        Get-EventsFilter -ID 4663 -NamedDataFilter @{'SubjectUserName'='john.doe'} -LogName 'ForwardedEvents'
+
+        This will return an XPath filter that will return any events with
+        the id of 4663 and has a SubjectUserName of 'john.doe'
+
+        Output:
+        <QueryList>
+            <Query Id="0" Path="ForwardedEvents">
+                <Select Path="ForwardedEvents">
+                        (*[System[EventID=4663]]) and (*[EventData[Data[@Name='SubjectUserName'] = 'john.doe']])
+                </Select>
+            </Query>
+        </QueryList>
+
+        .EXAMPLE
+        Get-EventsFilter -StartTime '1/1/2015 01:30:00 PM' -EndTime '1/1/2015 02:00:00 PM' -LogName 'ForwardedEvents
+
+        This will return an XPath filter that will return events that occured between 1:30
+        2:00 PM on 1/1/2015.  The filter will only be good if used immediately.  XPath time
+        filters are based on the number of milliseconds that have occured since the event
+        and when the filter is used.  StartTime and EndTime simply calculate the number of
+        milliseconds and use that for the filter.
+
+        Output:
+        <QueryList>
+            <Query Id="0" Path="ForwardedEvents">
+                <Select Path="ForwardedEvents">
+                        (*[System[TimeCreated[timediff(@SystemTime) &lt;= 125812885399]]]) and (*[System[TimeCreated[timediff(@SystemTime)
+    &gt;= 125811085399]]])
+                </Select>
+            </Query>
+        </QueryList>
+
+        .EXAMPLE
+        Get-EventsFilter -StartTime (Get-Date).AddDays(-1) -LogName System
+
+        This will return an XPath filter that will get events that occured within the last 24 hours.
+
+        Output:
+        <QueryList>
+            <Query Id="0" Path="System">
+                    <Select Path="System">
+                        *[System[TimeCreated[timediff(@SystemTime) &lt;= 86404194]]]
+                </Select>
+            </Query>
+        </QueryList>
+
+        .EXAMPLE
+        Get-EventsFilter -ID 1105 -LogName 'ForwardedEvents' -RecordID '3512231','3512232'
+
+        This will return an XPath filter that will get events with EventRecordID 3512231 or 3512232 in Log ForwardedEvents with EventID 1105
+
+        Output:
+        <QueryList>
+            <Query Id="0" Path="ForwardedEvents">
+                    <Select Path="ForwardedEvents">
+                        (*[System[EventID=1105]]) and (*[System[(EventRecordID=3512231) or (EventRecordID=3512232)]])
+                </Select>
+            </Query>
+        </QueryList>
+        #>
+
+        [CmdletBinding()]
+        Param
+        (
+            [String[]]
+            $ID,
+
+            [alias('RecordID')][string[]]
+            $EventRecordID,
+
+            [DateTime]
+            $StartTime,
+
+            [DateTime]
+            $EndTime,
+
+            [String[]]
+            $Data,
+
+            [String[]]
+            $ProviderName,
+
+            [Long[]]
+            $Keywords,
+
+            [ValidateSet(
+                'Critical',
+                'Error',
+                'Informational',
+                'LogAlways',
+                'Verbose',
+                'Warning'
+            )]
+            [String[]]
+            $Level,
+
+            [String[]]
+            $UserID,
+
+            [Hashtable[]]
+            $NamedDataFilter,
+
+            [Hashtable[]]
+            $NamedDataExcludeFilter,
+
+            [String[]]
+            $ExcludeID,
+
+            [String]
+            $LogName,
+
+            [String]
+            $Path,
+
+            [switch] $XPathOnly
+        )
+
+        #region Function definitions
+        Function Join-XPathFilter {
+            Param
+            (
+                [Parameter(
+                    Mandatory = $True,
+                    Position = 0
+                )]
+                [String]
+                $NewFilter,
+
+                [Parameter(
+                    Position = 1
+                )]
+                [String]
+                $ExistingFilter = '',
+
+                [Parameter(
+                    Position = 2
+                )]
+                # and and or are case sensitive
+                # in xpath
+                [ValidateSet(
+                    "and",
+                    "or",
+                    IgnoreCase = $False
+                )]
+                [String]
+                $Logic = 'and',
+
+                [switch]$NoParenthesis
+            )
+
+            If ($ExistingFilter) {
+                # If there is an existing filter add parenthesis unless noparenthesis is specified
+                # and the logical operator
+                if ($NoParenthesis) {
+                    Return "$ExistingFilter $Logic $NewFilter"
+                } Else {
+                    Return "($ExistingFilter) $Logic ($NewFilter)"
+                }
+            } Else {
+                Return $NewFilter
+            }
+            <#
+        .SYNOPSIS
+        This function handles the parenthesis and logical joining
+        of XPath statements inside of Get-EventsFilter
+        #>
+        }
+
+        Function Initialize-XPathFilter {
+            Param
+            (
+                [Object[]]
+                $Items,
+
+                [String]
+                $ForEachFormatString,
+
+                [String]
+                $FinalizeFormatString,
+
+                [ValidateSet("and", "or", IgnoreCase = $False)]
+                [String]
+                $Logic = 'or',
+
+                [switch]$NoParenthesis
+            )
+
+            $filter = ''
+
+            ForEach ($item in $Items) {
+                $options = @{'NewFilter' = ($ForEachFormatString -f $item)
+                    'ExistingFilter'     = $filter
+                    'Logic'              = $logic
+                    'NoParenthesis'      = $NoParenthesis
+                }
+                $filter = Join-XPathFilter @options
+            }
+
+            Return $FinalizeFormatString -f $filter
+            <#
+        .SYNOPSIS
+        This function loops thru a set of items and injecting each
+        item in the format string given by ForEachFormatString, then
+        combines each of those items together with 'or' logic
+        using the function Join-XPathFilter, which handles the
+        joining and parenthesis.  Before returning the result,
+        it injects the resultant xpath into FinalizeFormatString.
+
+        This function is a part of Get-EventsFilter
+        #>
+        }
+        #endregion Function definitions
+
+        [string] $filter = ''
+
+        #region ID filter
+        If ($ID) {
+            $options = @{
+                'Items'                = $ID
+                'ForEachFormatString'  = "EventID={0}"
+                'FinalizeFormatString' = "*[System[{0}]]"
+            }
+            $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter (Initialize-XPathFilter @options)
+        }
+        #endregion ID filter
+
+        # region EventRecordID filter
+        If ($EventRecordID) {
+            $options = @{
+                'Items'                = $EventRecordID
+                'ForEachFormatString'  = "EventRecordID={0}"
+                'FinalizeFormatString' = "*[System[{0}]]"
+            }
+            $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter (Initialize-XPathFilter @options)
+        }
+        #endregion EventRecordID filter
+
+        #region Exclude ID filter
+        If ($ExcludeID) {
+            $options = @{
+                'Items'                = $ExcludeID
+                'ForEachFormatString'  = "EventID!={0}"
+                'FinalizeFormatString' = "*[System[{0}]]"
+            }
+            $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter (Initialize-XPathFilter @options)
+        }
+        #endregion Exclude ID filter
+
+        #region Date filters
+        $Now = Get-Date
+
+        # Time in XPath is filtered based on the number of milliseconds
+        # between the creation of the event and when the XPath filter is
+        # used.
+        #
+        # The timediff xpath function is used against the SystemTime
+        # attribute of the TimeCreated node.
+
+        ## Special chars needs replacement
+        # <= is &lt;=
+        # <  is &lt;
+        # >  is &gt;
+        # >= is &gt;=
+        #
+
+        If ($StartTime) {
+            $Diff = [Math]::Round($Now.Subtract($StartTime).TotalMilliseconds)
+            $filter = Join-XPathFilter -NewFilter "*[System[TimeCreated[timediff(@SystemTime) &lt;= $Diff]]]" -ExistingFilter $filter
+        }
+
+        If ($EndTime) {
+            $Diff = [Math]::Round($Now.Subtract($EndTime).TotalMilliseconds)
+            $filter = Join-XPathFilter -NewFilter "*[System[TimeCreated[timediff(@SystemTime) &gt;= $Diff]]]" -ExistingFilter $filter
+        }
+        #endregion Date filters
+
+        #region Data filter
+        If ($Data) {
+            $options = @{
+                'Items'                = $Data
+                'ForEachFormatString'  = "Data='{0}'"
+                'FinalizeFormatString' = "*[EventData[{0}]]"
+            }
+            $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter (Initialize-XPathFilter @options)
+        }
+        #endregion Data filter
+
+        #region ProviderName filter
+        If ($ProviderName) {
+            $options = @{
+                'Items'                = $ProviderName
+                'ForEachFormatString'  = "@Name='{0}'"
+                'FinalizeFormatString' = "*[System[Provider[{0}]]]"
+            }
+            $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter (Initialize-XPathFilter @options)
+        }
+        #endregion ProviderName filter
+
+        #region Level filter
+        If ($Level) {
+            $levels = ForEach ($item in $Level) {
+                # Levels in an event's XML are defined
+                # with integer values.
+                [Int][System.Diagnostics.Tracing.EventLevel]::$item
+            }
+
+            $options = @{
+                'Items'                = $levels
+                'ForEachFormatString'  = "Level={0}"
+                'FinalizeFormatString' = "*[System[{0}]]"
+            }
+            $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter (Initialize-XPathFilter @options)
+        }
+        #endregion Level filter
+
+        #region Keyword filter
+        # Keywords are stored as a long integer
+        # numeric value.  That integer is the
+        # flagged (binary) combination of
+        # all the keywords.
+        #
+        # By combining all given keywords
+        # with a binary OR operation, and then
+        # taking the resultant number and
+        # comparing that against the number
+        # stored in the events XML with a
+        # binary AND operation will return
+        # events that have any of the submitted
+        # keywords assigned.
+        If ($Keywords) {
+            $keyword_filter = ''
+
+            ForEach ($item in $Keywords) {
+                If ($keyword_filter) {
+                    $keyword_filter = $keyword_filter -bor $item
+                } Else {
+                    $keyword_filter = $item
+                }
+            }
+
+            $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter "*[System[band(Keywords,$keyword_filter)]]"
+        }
+        #endregion Keyword filter
+
+        #region UserID filter
+        # The UserID attribute of the Security node contains a Sid.
+        If ($UserID) {
+            $sids = ForEach ($item in $UserID) {
+                Try {
+                    #If the value submitted isn't a valid sid, it'll error.
+                    $sid = [System.Security.Principal.SecurityIdentifier]($item)
+                    $sid = $sid.Translate([System.Security.Principal.SecurityIdentifier])
+                } Catch [System.Management.Automation.RuntimeException] {
+                    # If a RuntimeException occured with an InvalidArgument category
+                    # attempt to create an NTAccount object and resolve.
+                    If ($Error[0].CategoryInfo.Category -eq 'InvalidArgument') {
+                        Try {
+                            $user = [System.Security.Principal.NTAccount]($item)
+                            $sid = $user.Translate([System.Security.Principal.SecurityIdentifier])
+                        } Catch {
+                            #There was an error with either creating the NTAccount or
+                            #Translating that object to a sid.
+                            Throw $Error[0]
+                        }
+                    } Else {
+                        #There was a RuntimeException from either creating the
+                        #SecurityIdentifier object or the translation
+                        #and the category was not InvalidArgument
+                        Throw $Error[0]
+                    }
+                } Catch {
+                    #There was an error from ether the creation of the SecurityIdentifier
+                    #object or the Translatation
+                    Throw $Error[0]
+                }
+
+                $sid.Value
+            }
+
+            $options = @{
+                'Items'                = $sids
+                'ForEachFormatString'  = "@UserID='{0}'"
+                'FinalizeFormatString' = "*[System[Security[{0}]]]"
+            }
+            $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter (Initialize-XPathFilter @options)
+        }
+        #endregion UserID filter
+
+        #region NamedDataFilter
+        If ($NamedDataFilter) {
+            $options = @{
+                'Items'                = $(
+                    # This will create set of datafilters for each of
+                    # the hash tables submitted in the hash table array
+                    ForEach ($item in $NamedDataFilter) {
+                        $options = @{
+                            'Items'                = $(
+                                #This will result in as set of XPath subexpressions
+                                #for each key submitted in the hashtable
+                                ForEach ($key in $item.Keys) {
+                                    If ($item[$key]) {
+                                        #If there is a value for the key, create the
+                                        #XPath for the Data node with that Name attribute
+                                        #and value. Use 'and' logic to join the data values.
+                                        #to the Name Attribute.
+                                        $options = @{
+                                            'Items'                = $item[$key]
+                                            'NoParenthesis'        = $true
+                                            'ForEachFormatString'  = "Data[@Name='$key'] = '{0}'"
+                                            'FinalizeFormatString' = "{0}"
+                                        }
+                                        Initialize-XPathFilter @options
+                                    } Else {
+                                        #If there isn't a value for the key, create
+                                        #XPath for the existence of the Data node with
+                                        #that paritcular Name attribute.
+                                        "Data[@Name='$key']"
+                                    }
+                                }
+                            )
+                            'ForEachFormatString'  = "{0}"
+                            'FinalizeFormatString' = "{0}"
+                        }
+                        Initialize-XPathFilter @options
+                    }
+                )
+                'ForEachFormatString'  = "{0}"
+                'FinalizeFormatString' = "*[EventData[{0}]]"
+
+            }
+            $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter (Initialize-XPathFilter @options)
+        }
+        #endregion NamedDataFilter
+
+        #region NamedDataExcludeFilter
+        If ($NamedDataExcludeFilter) {
+            $options = @{
+                'Items'                = $(
+                    # This will create set of datafilters for each of
+                    # the hash tables submitted in the hash table array
+                    ForEach ($item in $NamedDataExcludeFilter) {
+                        $options = @{
+                            'Items'                = $(
+                                #This will result in as set of XPath subexpressions
+                                #for each key submitted in the hashtable
+                                ForEach ($key in $item.Keys) {
+                                    If ($item[$key]) {
+                                        #If there is a value for the key, create the
+                                        #XPath for the Data node with that Name attribute
+                                        #and value. Use 'and' logic to join the data values.
+                                        #to the Name Attribute.
+                                        $options = @{
+                                            'Items'                = $item[$key]
+                                            'NoParenthesis'        = $true
+                                            'ForEachFormatString'  = "Data[@Name='$key'] != '{0}'"
+                                            'FinalizeFormatString' = "{0}"
+                                            'Logic'                = 'and'
+                                        }
+                                        Initialize-XPathFilter @options
+                                    } Else {
+                                        #If there isn't a value for the key, create
+                                        #XPath for the existence of the Data node with
+                                        #that paritcular Name attribute.
+                                        "Data[@Name='$key']"
+                                    }
+                                }
+                            )
+                            'ForEachFormatString'  = "{0}"
+                            'FinalizeFormatString' = "{0}"
+                        }
+                        Initialize-XPathFilter @options
+                    }
+                )
+                'ForEachFormatString'  = "{0}"
+                'FinalizeFormatString' = "*[EventData[{0}]]"
+
+            }
+            $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter (Initialize-XPathFilter @options)
+        }
+        #endregion NamedDataExcludeFilter
+
+        if ($XPathOnly) {
+            return $Filter
+        } else {
+            if ($Path -ne '') {
+                $FilterXML = @"
+                    <QueryList>
+                        <Query Id="0" Path="file://$Path">
+                            <Select>
+                                    $filter
+                            </Select>
+                        </Query>
+                    </QueryList>
+"@
+            } else {
+                $FilterXML = @"
+                    <QueryList>
+                        <Query Id="0" Path="$LogName">
+                            <Select Path="$LogName">
+                                    $filter
+                            </Select>
+                        </Query>
+                    </QueryList>
+"@
+            }
+            return $FilterXML
+        }
+    } # Function Get-EventsFilter
+    function Get-EventsInternal () {
+        [CmdLetBinding()]
+        param (
+            [string]$Comp,
+            [ValidateNotNull()]
+            [alias('Credentials')][System.Management.Automation.PSCredential]
+            [System.Management.Automation.Credential()]$Credential = [System.Management.Automation.PSCredential]::Empty,
+            [hashtable]$EventFilter,
+            [int]$MaxEvents,
+            [switch] $Oldest
+        )
+        $Measure = [System.Diagnostics.Stopwatch]::StartNew() # Timer Start
+
+        Write-Verbose "Get-Events - Inside $Comp for Events ID: $($EventFilter.ID)"
+        Write-Verbose "Get-Events - Inside $Comp for Events LogName: $($EventFilter.LogName)"
+        Write-Verbose "Get-Events - Inside $Comp for Events RecordID: $($EventFilter.RecordID)"
+        Write-Verbose "Get-Events - Inside $Comp for Events Oldest: $Oldest"
+        try {
+            [Array] $Events = @(
+                if ($null -ne $EventFilter.RecordID -or `
+                        $null -ne $EventFilter.NamedDataFilter -or `
+                        $null -ne $EventFilter.ExcludeID -or `
+                        $null -ne $EventFilter.NamedDataExcludeFilter -or `
+                        $null -ne $EventFilter.UserID
+                ) {
+                    $FilterXML = Get-EventsFilter @EventFilter
+                    $SplatEvents = @{
+                        ErrorAction  = 'Stop'
+                        ComputerName = $Comp
+                        Oldest       = $Oldest
+                        FilterXml    = $FilterXML
+                    }
+                    Write-Verbose "Get-Events - Inside $Comp - Custom FilterXML: `n$FilterXML"
+                } else {
+                    $SplatEvents = @{
+                        ErrorAction     = 'Stop'
+                        ComputerName    = $Comp
+                        Oldest          = $Oldest
+                        FilterHashtable = $EventFilter
+                    }
+                    foreach ($k in $EventFilter.Keys) {
+                        Write-Verbose "Get-Events - Inside $Comp Data in FilterHashTable $k $($EventFilter[$k])"
+                    }
+                }
+                if ($MaxEvents -ne 0) {
+                    $SplatEvents.MaxEvents = $MaxEvents
+                    Write-Verbose "Get-Events - Inside $Comp for Events Max Events: $MaxEvents"
+                }
+                if ($Credential -ne [System.Management.Automation.PSCredential]::Empty) {
+                    $SplatEvents.Credential = $Credential
+                    Write-Verbose "Get-Events - Inside $Comp for Events Credential: $Credential"
+                }
+                Get-WinEvent @SplatEvents
+            )
+            #$EventsCount = ($Events | Measure-Object).Count
+            Write-Verbose -Message "Get-Events - Inside $Comp Events found $($Events.Count)"
+        } catch {
+            if ($_.Exception -match "No events were found that match the specified selection criteria") {
+                Write-Verbose -Message "Get-Events - Inside $Comp No events found."
+            } elseif ($_.Exception -match "There are no more endpoints available from the endpoint") {
+                Write-Verbose -Message "Get-Events - Inside $Comp Error $($_.Exception.Message)"
+                Write-Error -Message "$Comp`: $_"
+            } else {
+                Write-Verbose -Message "Get-Events - Inside $Comp Error $($_.Exception.Message)"
+                Write-Error -Message "$Comp`: $_"
+            }
+            Write-Verbose "Get-Events - Inside $Comp Time to generate $($Measure.Elapsed.Hours) hours, $($Measure.Elapsed.Minutes) minutes, $($Measure.Elapsed.Seconds) seconds, $($Measure.Elapsed.Milliseconds) milliseconds"
+            $Measure.Stop()
+            return
+        }
+        Write-Verbose "Get-Events - Inside $Comp Processing events..."
+
+        # Parse out the event message data
+        ForEach ($Event in $Events) {
+            # Convert the event to XML
+            $eventXML = [xml]$Event.ToXml()
+            # Iterate through each one of the XML message properties
+            #Add-Member -InputObject $Event -MemberType NoteProperty -Name "Computer" -Value $event.MachineName.ToString() -Force
+            #Add-Member -InputObject $Event -MemberType NoteProperty -Name "Date" -Value $Event.TimeCreated -Force
+            $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('Computer', $event.MachineName.ToString()))
+            $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('Date', $Event.TimeCreated))
+
+            #$EventTopNodes = Get-Member -InputObject $eventXML.Event -MemberType Properties | Where-Object { $_.Name -ne 'System' -and $_.Name -ne 'xmlns' }
+            $EventTopNodes = $eventXML.Event.PSAdapted.PSObject.Properties.Name #| Where-Object { $_ -ne 'System' -and $_ -ne 'xmlns' }
+
+            [Array] $EventTopNodes = foreach ($Entry in $EventTopNodes) {
+                if ($Entry -ne 'System' -and $Entry -ne 'xmlns' ) {
+                    $Entry
+                }
+            }
+            foreach ($TopNode in $EventTopNodes) {
+                #$TopNode = $EventTopNode.Name
+
+                #$EventSubsSubs = Get-Member -InputObject $eventXML.Event.$TopNode -MemberType Properties
+                $EventSubsSubs = $eventXML.Event.$TopNode.PSAdapted.PSObject.Properties
+                $h = 0
+                foreach ($EventSubSub in $EventSubsSubs) {
+                    $SubNode = $EventSubSub.Name
+                    #$EventSubSub | ft -a
+                    if ($EventSubSub.TypeNameOfValue -like "System.Object*") {
+                        #if (Get-Member -InputObject $eventXML.Event.$TopNode -Name "$SubNode" -MemberType Properties) {
+                        if ($eventXML.Event.$TopNode.$SubNode) {
+                            # Case 1
+                            #$SubSubNode = Get-Member -InputObject $eventXML.Event.$TopNode.$SubNode -MemberType Properties | Where-Object { $_.Name -ne 'xmlns' -and $_.Definition -like "string*" }
+                            $SubSubNode = $eventXML.Event.$TopNode.$SubNode.PSAdapted.PSObject.Properties #| Where-Object { $_.Name -ne 'xmlns' -and $_.TypeNameOfValue -like "string*" }
+                            [Array] $SubSubNode = foreach ($Entry in $SubSubNode) {
+                                if ($Entry.Name -ne 'xmls' -and $_.TypeNameOfValue -like "string*") {
+                                    $Entry
+                                }
+                            }
+                            foreach ($Name in $SubSubNode.Name) {
+                                $fieldName = $Name
+                                $fieldValue = $eventXML.Event.$TopNode.$SubNode.$Name
+                                #Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $fieldValue -Force
+                                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new($fieldName, $fieldValue))
+                            }
+                            # Case 1
+
+                            For ($i = 0; $i -lt $eventXML.Event.$TopNode.$SubNode.Count; $i++) {
+                                #if (Get-Member -InputObject $eventXML.Event.$TopNode.$SubNode[$i] -Name "Name" -MemberType Properties) {
+                                if ($eventXML.Event.$TopNode.$SubNode[$i].Name) {
+                                    # Case 2
+                                    $fieldName = $eventXML.Event.$TopNode.$SubNode[$i].Name
+                                    #if (Get-Member -InputObject $eventXML.Event.$TopNode.$SubNode[$i] -Name "#text" -MemberType Properties) {
+                                    if ($eventXML.Event.$TopNode.$SubNode[$i]."#text") {
+                                        $fieldValue = $eventXML.Event.$TopNode.$SubNode[$i]."#text"
+                                        if ($fieldValue -eq "-".Trim()) { $fieldValue = $fieldValue -replace "-" }
+                                    } else {
+                                        $fieldValue = ""
+                                    }
+                                    if ($fieldName -ne "") {
+                                        #Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $fieldValue -Force
+                                        $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new($fieldName, $fieldValue))
+                                    }
+                                    # Case 2
+                                } else {
+                                    # Case 3
+                                    $Value = $eventXML.Event.$TopNode.$SubNode[$i]
+                                    if ($Value.Name -ne 'Name' -and $Value.Name -ne '#text') {
+                                        $fieldName = "NoNameA$i"
+                                        $fieldValue = $Value
+                                        # Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $fieldValue -Force
+                                        $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new($fieldName, $fieldValue))
+                                    }
+                                    # Case 3
+                                }
+
+                            }
+                        }
+                    } elseif ($EventSubSub.TypeNameOfValue -like "System.Xml.XmlElement*") {
+                        # Case 1
+                        #$SubSubNode = Get-Member -InputObject $eventXML.Event.$TopNode.$SubNode -MemberType Properties | Where-Object { $_.Name -ne 'xmlns' -and $_.Definition -like "string*" }
+                        $SubSubNode = $eventXML.Event.$TopNode.$SubNode.PSAdapted.PSObject.Properties #| Where-Object { $_.Name -ne 'xmlns' -and $_.TypeNameOfValue -like "string*" }
+                        [Array] $SubSubNode = foreach ($Entry in $SubSubNode) {
+                            if ($Entry.Name -ne 'xmls' -and $_.TypeNameOfValue -like "string*") {
+                                $Entry
+                            }
+                        }
+                        foreach ($Name in $SubSubNode.Name) {
+                            $fieldName = $Name
+                            $fieldValue = $eventXML.Event.$TopNode.$SubNode.$Name
+                            # Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $fieldValue -Force
+                            $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new($fieldName, $fieldValue))
+                        }
+                        # Case 1
+                    } else {
+                        # Case 4 - Where Data has no Names
+                        $fieldValue = $eventXML.Event.$TopNode.$SubNode
+                        if ($fieldValue -match "\n") {
+                            # this is case with ADConnect - event id 6946 where 1 Value has multiple values line per line
+                            $SplittedValues = $fieldValue -split '\n'
+                            foreach ($Split in $SplittedValues) {
+                                $h++
+                                $fieldName = "NoNameB$h"
+                                #Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $Split -Force
+                                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new($fieldName, $Split))
+                            }
+                        } else {
+                            $h++
+                            $fieldName = "NoNameB$h"
+                            #Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $fieldValue -Force
+                            $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new($fieldName, $fieldValue))
+                        }
+                        # Case 4
+                    }
+                }
+            }
+            # This adds some fields specific to PSWinReporting
+            [string] $MessageSubject = ($Event.Message -split '\n')[0] -replace "`n", '' -replace "`r", '' -replace "`t", ''
+            #Add-Member -InputObject $Event -MemberType NoteProperty -Name 'MessageSubject' -Value $MessageSubject -Force
+            #Add-Member -InputObject $Event -MemberType NoteProperty -Name 'Action' -Value $MessageSubject -Force
+            $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('MessageSubject', $MessageSubject))
+            $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('Action', $MessageSubject))
+
+            # Level value is not needed because there is actually LevelDisplayName
+            #Add-Member -InputObject $Event -MemberType NoteProperty -Name 'LevelTranslated' -Value ([PSEventViewer.Level] $Event.Level)
+
+            # Overwrite value - the old value is collection
+            # Add-Member -InputObject $Event -MemberType NoteProperty -Name 'KeywordDisplayName' -Value ($Event.KeywordsDisplayNames -join ',') -Force
+            $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('KeywordDisplayName', ($Event.KeywordsDisplayNames -join ',')))
+
+            if ($Event.SubjectDomainName -and $Event.SubjectUserName) {
+                #Add-Member -InputObject $Event -MemberType NoteProperty -Name 'Who' -Value "$($Event.SubjectDomainName)\$($Event.SubjectUserName)" -Force
+                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('Who', "$($Event.SubjectDomainName)\$($Event.SubjectUserName)" ))
+            } elseif ($Event.SubjectUserName) {
+                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('Who', "$($Event.SubjectUserName)"))
+            }
+            if ($Event.TargetDomainName -and $Event.TargetUserName) {
+                #Add-Member -InputObject $Event -MemberType NoteProperty -Name 'ObjectAffected' -Value "$($Event.TargetDomainName)\$($Event.TargetUserName)" -Force
+                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('ObjectAffected', "$($Event.TargetDomainName)\$($Event.TargetUserName)"))
+            } elseif ($Event.TargetUserName) {
+                # Add-Member -InputObject $Event -MemberType NoteProperty -Name 'ObjectAffected' -Value "$($Event.TargetUserName)" -Force
+                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('ObjectAffected', "$($Event.TargetUserName)"))
+            }
+            if ($Event.MemberName) {
+                [string] $MemberNameWithoutCN = $Event.MemberName -replace 'CN=|\\|,(OU|DC|CN).*$'
+                #Add-Member -InputObject $Event -MemberType NoteProperty -Name 'MemberNameWithoutCN' -Value $MemberNameWithoutCN -Force
+                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('MemberNameWithoutCN', $MemberNameWithoutCN))
+            }
+            if ($EventFilter.Path) {
+                #Add-Member -InputObject $Event -MemberType NoteProperty -Name "GatheredFrom" -Value $EventFilter.Path -Force
+                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('GatheredFrom', $EventFilter.Path))
+            } else {
+                #Add-Member -InputObject $Event -MemberType NoteProperty -Name "GatheredFrom" -Value $Comp -Force
+                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('GatheredFrom', $Comp))
+            }
+            #Add-Member -InputObject $Event -MemberType NoteProperty -Name "GatheredLogName" -Value $EventFilter.LogName -Force
+            $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('GatheredLogName', $EventFilter.LogName))
+        }
+        Write-Verbose "Get-Events - Inside $Comp Time to generate $($Measure.Elapsed.Hours) hours, $($Measure.Elapsed.Minutes) minutes, $($Measure.Elapsed.Seconds) seconds, $($Measure.Elapsed.Milliseconds) milliseconds"
+        $Measure.Stop()
+        return $Events
+    }
+    Write-Verbose "Get-Events -------------START---------------------"
+    [Array] $Data = Get-EventsInternal -Comp $Comp -EventFilter $EventFilter -MaxEvents $MaxEvents -Oldest:$Oldest -Verbose:$Verbose -Credential $Credential
+    Write-Verbose "Get-Events --------------END----------------------"
+    return $Data
+}

--- a/Private/ScriptBlock.ps1
+++ b/Private/ScriptBlock.ps1
@@ -231,16 +231,7 @@ $Script:ScriptBlock = {
             } ElseIf (-not $Value.Contains([String] $DoubleQuote)) {
                 $Literal = [String] $DoubleQuote + $Value + [String] $DoubleQuote
             } Else {
-                $Parts = $Value.Split($SingleQuote)
-                [Array] $Segments = For ($Index = 0; $Index -lt $Parts.Length; $Index++) {
-                    If ($Parts[$Index].Length -gt 0) {
-                        [String] $SingleQuote + $Parts[$Index] + [String] $SingleQuote
-                    }
-                    If ($Index -lt $Parts.Length - 1) {
-                        [String] $DoubleQuote + [String] $SingleQuote + [String] $DoubleQuote
-                    }
-                }
-                $Literal = 'concat(' + ($Segments -join ',') + ')'
+                throw 'Windows Event Log XPath cannot represent a string containing both single and double quotes.'
             }
 
             [System.Security.SecurityElement]::Escape($Literal)
@@ -642,7 +633,7 @@ $Script:ScriptBlock = {
             if ($SuppressFilter) {
                 throw 'NamedDataExcludeFilter requires FilterXml output so excluded matches can be represented with a Suppress query.'
             }
-            return $Filter
+            return [System.Net.WebUtility]::HtmlDecode([String] $Filter)
         } else {
             if ($Path -ne '') {
                 $EscapedPath = [System.Security.SecurityElement]::Escape("file://$Path")

--- a/Private/ScriptBlock.ps1
+++ b/Private/ScriptBlock.ps1
@@ -7,7 +7,9 @@ $Script:ScriptBlock = {
         [hashtable]$EventFilter,
         [int]$MaxEvents,
         [bool] $Oldest,
-        [bool] $Verbose
+        [bool] $Verbose,
+        [int] $EntryIndex = -1,
+        [bool] $IncludeEntryIndex = $false
     )
     if ($Verbose) {
         $VerbosePreference = 'continue'
@@ -481,8 +483,12 @@ $Script:ScriptBlock = {
         # keywords assigned.
         If ($null -ne $Keywords -and $Keywords.Count -gt 0) {
             $keyword_filter = ''
+            [bool] $HasZeroKeyword = $false
 
             ForEach ($item in $Keywords) {
+                if ([long] $item -eq 0) {
+                    $HasZeroKeyword = $true
+                }
                 If ($keyword_filter) {
                     $keyword_filter = $keyword_filter -bor $item
                 } Else {
@@ -492,6 +498,8 @@ $Script:ScriptBlock = {
 
             if ($keyword_filter -eq 0) {
                 $KeywordXPath = '*[System[Keywords=0]]'
+            } elseif ($HasZeroKeyword) {
+                $KeywordXPath = "*[System[Keywords=0 or band(Keywords,$keyword_filter)]]"
             } else {
                 $KeywordXPath = "*[System[band(Keywords,$keyword_filter)]]"
             }
@@ -687,6 +695,15 @@ $Script:ScriptBlock = {
                 [Array] $PostNamedDataExclusions = @()
                 [bool] $IsPathQuery = $null -ne $EventFilter.Path
                 [bool] $IsProviderQuery = -not $IsPathQuery -and $null -eq $EventFilter.LogName -and $null -ne $EventFilter.ProviderName
+                [bool] $IsLogWildcardQuery = $false
+                if (-not $IsPathQuery -and $null -ne $EventFilter.LogName) {
+                    ForEach ($LogPattern in @($EventFilter.LogName)) {
+                        if ([System.Management.Automation.WildcardPattern]::ContainsWildcardCharacters([String] $LogPattern)) {
+                            $IsLogWildcardQuery = $true
+                            break
+                        }
+                    }
+                }
                 if ($null -ne $EventFilter.RecordID -or `
                         $null -ne $EventFilter.NamedDataFilter -or `
                         $null -ne $EventFilter.ExcludeID -or `
@@ -707,7 +724,10 @@ $Script:ScriptBlock = {
                             $FilterForQuery.Remove('ProviderName')
                         }
                     }
-                    if ($IsPathQuery -or $IsProviderQuery) {
+                    if ($IsLogWildcardQuery) {
+                        $FilterForQuery.Remove('LogName')
+                    }
+                    if ($IsPathQuery -or $IsProviderQuery -or $IsLogWildcardQuery) {
                         if ($FilterForQuery.NamedDataExcludeFilter) {
                             [Array] $PostNamedDataExclusions = @($FilterForQuery.NamedDataExcludeFilter)
                             $FilterForQuery.Remove('NamedDataExcludeFilter')
@@ -724,10 +744,14 @@ $Script:ScriptBlock = {
                         if ($IsPathQuery) {
                             $SplatEvents.Path = $EventFilter.Path
                             Write-Verbose "Get-Events - Inside $Comp - Custom FilterXPath for path: `n$FilterXPath"
-                        } else {
+                        } elseif ($IsProviderQuery) {
                             $SplatEvents.ProviderName = $EventFilter.ProviderName
                             $SplatEvents.ComputerName = $Comp
                             Write-Verbose "Get-Events - Inside $Comp - Custom FilterXPath for provider: `n$FilterXPath"
+                        } else {
+                            $SplatEvents.LogName = $EventFilter.LogName
+                            $SplatEvents.ComputerName = $Comp
+                            Write-Verbose "Get-Events - Inside $Comp - Custom FilterXPath for wildcard log: `n$FilterXPath"
                         }
                     } else {
                         $FilterXML = Get-EventsFilter @FilterForQuery
@@ -1010,5 +1034,14 @@ $Script:ScriptBlock = {
     Write-Verbose "Get-Events -------------START---------------------"
     [Array] $Data = Get-EventsInternal -Comp $Comp -EventFilter $EventFilter -MaxEvents $MaxEvents -Oldest:$Oldest -Verbose:$Verbose -Credential $Credential
     Write-Verbose "Get-Events --------------END----------------------"
-    return $Data
+    if ($IncludeEntryIndex) {
+        foreach ($EventData in $Data) {
+            [PSCustomObject] @{
+                EntryIndex = $EntryIndex
+                Event      = $EventData
+            }
+        }
+    } else {
+        return $Data
+    }
 }

--- a/Private/ScriptBlock.ps1
+++ b/Private/ScriptBlock.ps1
@@ -191,15 +191,7 @@ $Script:ScriptBlock = {
             [Long[]]
             $Keywords,
 
-            [ValidateSet(
-                'Critical',
-                'Error',
-                'Informational',
-                'LogAlways',
-                'Verbose',
-                'Warning'
-            )]
-            [String[]]
+            [Object[]]
             $Level,
 
             [String[]]
@@ -439,11 +431,29 @@ $Script:ScriptBlock = {
         #endregion ProviderName filter
 
         #region Level filter
-        If ($Level) {
+        If ($null -ne $Level -and $Level.Count -gt 0) {
+            $NamedLevels = @{
+                Critical      = 1
+                Error         = 2
+                Warning       = 3
+                Informational = 4
+                Verbose       = 5
+                LogAlways     = 0
+            }
             $levels = ForEach ($item in $Level) {
                 # Levels in an event's XML are defined
                 # with integer values.
-                [Int][System.Diagnostics.Tracing.EventLevel]::$item
+                $NumericLevel = 0
+                if ([Int]::TryParse([String] $item, [ref] $NumericLevel)) {
+                    if ($NumericLevel -lt 0 -or $NumericLevel -gt 5) {
+                        throw "Event level '$item' must be between 0 and 5."
+                    }
+                    $NumericLevel
+                } elseif ($NamedLevels.ContainsKey([String] $item)) {
+                    $NamedLevels[[String] $item]
+                } else {
+                    throw "Unknown event level '$item'."
+                }
             }
 
             $options = @{
@@ -469,7 +479,7 @@ $Script:ScriptBlock = {
         # binary AND operation will return
         # events that have any of the submitted
         # keywords assigned.
-        If ($Keywords) {
+        If ($null -ne $Keywords -and $Keywords.Count -gt 0) {
             $keyword_filter = ''
 
             ForEach ($item in $Keywords) {
@@ -480,7 +490,12 @@ $Script:ScriptBlock = {
                 }
             }
 
-            $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter "*[System[band(Keywords,$keyword_filter)]]"
+            if ($keyword_filter -eq 0) {
+                $KeywordXPath = '*[System[Keywords=0]]'
+            } else {
+                $KeywordXPath = "*[System[band(Keywords,$keyword_filter)]]"
+            }
+            $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter $KeywordXPath
         }
         #endregion Keyword filter
 
@@ -566,6 +581,7 @@ $Script:ScriptBlock = {
                             )
                             'ForEachFormatString'  = "{0}"
                             'FinalizeFormatString' = "{0}"
+                            'Logic'                = 'and'
                         }
                         Initialize-XPathFilter @options
                     }
@@ -616,6 +632,7 @@ $Script:ScriptBlock = {
                             )
                             'ForEachFormatString'  = "{0}"
                             'FinalizeFormatString' = "{0}"
+                            'Logic'                = 'and'
                         }
                         Initialize-XPathFilter @options
                     }
@@ -887,7 +904,8 @@ $Script:ScriptBlock = {
                 Add-Member -InputObject $Event -MemberType NoteProperty -Name 'GatheredFrom' -Value $Comp -Force
             }
             #Add-Member -InputObject $Event -MemberType NoteProperty -Name "GatheredLogName" -Value $EventFilter.LogName -Force
-            Add-Member -InputObject $Event -MemberType NoteProperty -Name 'GatheredLogName' -Value $EventFilter.LogName -Force
+            $GatheredLogName = if ($EventFilter.LogName) { $EventFilter.LogName } else { $Event.LogName }
+            Add-Member -InputObject $Event -MemberType NoteProperty -Name 'GatheredLogName' -Value $GatheredLogName -Force
         }
         Write-Verbose "Get-Events - Inside $Comp Time to generate $($Measure.Elapsed.Hours) hours, $($Measure.Elapsed.Minutes) minutes, $($Measure.Elapsed.Seconds) seconds, $($Measure.Elapsed.Milliseconds) milliseconds"
         $Measure.Stop()

--- a/Private/ScriptBlock.ps1
+++ b/Private/ScriptBlock.ps1
@@ -345,7 +345,7 @@ $Script:ScriptBlock = {
         [string] $filter = ''
 
         #region ID filter
-        If ($ID) {
+        If ($null -ne $ID -and @($ID).Count -gt 0) {
             $options = @{
                 'Items'                = $ID
                 'ForEachFormatString'  = "EventID={0}"
@@ -367,7 +367,7 @@ $Script:ScriptBlock = {
         #endregion EventRecordID filter
 
         #region Exclude ID filter
-        If ($ExcludeID) {
+        If ($null -ne $ExcludeID -and @($ExcludeID).Count -gt 0) {
             $options = @{
                 'Items'                = $ExcludeID
                 'ForEachFormatString'  = "EventID!={0}"
@@ -556,7 +556,7 @@ $Script:ScriptBlock = {
                                 #This will result in as set of XPath subexpressions
                                 #for each key submitted in the hashtable
                                 ForEach ($key in $item.Keys) {
-                                    If ($item[$key]) {
+                                    If (@($item[$key]).Count -gt 0 -and -not ($item[$key] -is [String] -and $item[$key].Length -eq 0)) {
                                         #If there is a value for the key, create the
                                         #XPath for the Data node with that Name attribute
                                         #and value. Use 'and' logic to join the data values.
@@ -596,75 +596,67 @@ $Script:ScriptBlock = {
 
         #region NamedDataExcludeFilter
         If ($NamedDataExcludeFilter) {
-            $options = @{
-                'Items'                = $(
-                    # This will create set of datafilters for each of
-                    # the hash tables submitted in the hash table array
-                    ForEach ($item in $NamedDataExcludeFilter) {
+            $ExcludedMatches = ForEach ($item in $NamedDataExcludeFilter) {
+                $KeyFilters = ForEach ($key in $item.Keys) {
+                    $KeyLiteral = ConvertTo-XPathXmlLiteral -Value ([String] $key)
+                    If (@($item[$key]).Count -gt 0 -and -not ($item[$key] -is [String] -and $item[$key].Length -eq 0)) {
                         $options = @{
-                            'Items'                = $(
-                                #This will result in as set of XPath subexpressions
-                                #for each key submitted in the hashtable
-                                ForEach ($key in $item.Keys) {
-                                    If ($item[$key]) {
-                                        #If there is a value for the key, create the
-                                        #XPath for the Data node with that Name attribute
-                                        #and value. Use 'and' logic to join the data values.
-                                        #to the Name Attribute.
-                                        $KeyLiteral = ConvertTo-XPathXmlLiteral -Value ([String] $key)
-                                        $options = @{
-                                            'Items'                = $item[$key]
-                                            'NoParenthesis'        = $true
-                                            'ForEachFormatString'  = "Data[@Name=$KeyLiteral] != {0}"
-                                            'FinalizeFormatString' = "{0}"
-                                            'Logic'                = 'and'
-                                            'EscapeItems'          = $true
-                                        }
-                                        Initialize-XPathFilter @options
-                                    } Else {
-                                        #If there isn't a value for the key, create
-                                        #XPath for the existence of the Data node with
-                                        #that paritcular Name attribute.
-                                        $KeyLiteral = ConvertTo-XPathXmlLiteral -Value ([String] $key)
-                                        "Data[@Name=$KeyLiteral]"
-                                    }
-                                }
-                            )
-                            'ForEachFormatString'  = "{0}"
+                            'Items'                = $item[$key]
+                            'NoParenthesis'        = $true
+                            'ForEachFormatString'  = "Data[@Name=$KeyLiteral] = {0}"
                             'FinalizeFormatString' = "{0}"
-                            'Logic'                = 'and'
+                            'EscapeItems'          = $true
                         }
                         Initialize-XPathFilter @options
+                    } Else {
+                        "Data[@Name=$KeyLiteral]"
                     }
-                )
-                'ForEachFormatString'  = "{0}"
-                'FinalizeFormatString' = "*[EventData[{0}]]"
-
+                }
+                $options = @{
+                    'Items'                = $KeyFilters
+                    'ForEachFormatString'  = "{0}"
+                    'FinalizeFormatString' = "{0}"
+                    'Logic'                = 'and'
+                }
+                $MatchingData = Initialize-XPathFilter @options
+                "*[EventData[$MatchingData]]"
             }
-            $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter (Initialize-XPathFilter @options)
+            $options = @{
+                'Items'                = $ExcludedMatches
+                'ForEachFormatString'  = "{0}"
+                'FinalizeFormatString' = "{0}"
+            }
+            $SuppressFilter = Initialize-XPathFilter @options
         }
         #endregion NamedDataExcludeFilter
 
         if ($XPathOnly) {
+            if ($SuppressFilter) {
+                throw 'NamedDataExcludeFilter requires FilterXml output so excluded matches can be represented with a Suppress query.'
+            }
             return $Filter
         } else {
             if ($Path -ne '') {
+                $EscapedPath = [System.Security.SecurityElement]::Escape("file://$Path")
                 $FilterXML = @"
                     <QueryList>
-                        <Query Id="0" Path="file://$Path">
+                        <Query Id="0" Path="$EscapedPath">
                             <Select>
                                     $filter
                             </Select>
+                            $(if ($SuppressFilter) { "<Suppress>$SuppressFilter</Suppress>" })
                         </Query>
                     </QueryList>
 "@
             } else {
+                $EscapedLogName = [System.Security.SecurityElement]::Escape($LogName)
                 $FilterXML = @"
                     <QueryList>
-                        <Query Id="0" Path="$LogName">
-                            <Select Path="$LogName">
+                        <Query Id="0" Path="$EscapedLogName">
+                            <Select Path="$EscapedLogName">
                                     $filter
                             </Select>
+                            $(if ($SuppressFilter) { "<Suppress Path=`"$EscapedLogName`">$SuppressFilter</Suppress>" })
                         </Query>
                     </QueryList>
 "@
@@ -691,20 +683,62 @@ $Script:ScriptBlock = {
         Write-Verbose "Get-Events - Inside $Comp for Events Oldest: $Oldest"
         try {
             [Array] $Events = @(
+                [bool] $PostFilterProvider = $false
+                [Array] $PostNamedDataExclusions = @()
+                [bool] $IsPathQuery = $null -ne $EventFilter.Path
+                [bool] $IsProviderQuery = -not $IsPathQuery -and $null -eq $EventFilter.LogName -and $null -ne $EventFilter.ProviderName
                 if ($null -ne $EventFilter.RecordID -or `
                         $null -ne $EventFilter.NamedDataFilter -or `
                         $null -ne $EventFilter.ExcludeID -or `
                         $null -ne $EventFilter.NamedDataExcludeFilter -or `
-                        $null -ne $EventFilter.UserID
+                        $null -ne $EventFilter.UserID -or `
+                        $IsPathQuery
                 ) {
-                    $FilterXML = Get-EventsFilter @EventFilter
-                    $SplatEvents = @{
-                        ErrorAction  = 'Stop'
-                        ComputerName = $Comp
-                        Oldest       = $Oldest
-                        FilterXml    = $FilterXML
+                    $FilterForQuery = $EventFilter.Clone()
+                    if ($FilterForQuery.ProviderName) {
+                        [Array] $ProviderPatterns = @($FilterForQuery.ProviderName)
+                        ForEach ($ProviderPattern in $ProviderPatterns) {
+                            if ([System.Management.Automation.WildcardPattern]::ContainsWildcardCharacters([String] $ProviderPattern)) {
+                                $PostFilterProvider = -not $IsProviderQuery
+                                break
+                            }
+                        }
+                        if ($PostFilterProvider -or $IsProviderQuery) {
+                            $FilterForQuery.Remove('ProviderName')
+                        }
                     }
-                    Write-Verbose "Get-Events - Inside $Comp - Custom FilterXML: `n$FilterXML"
+                    if ($IsPathQuery -or $IsProviderQuery) {
+                        if ($FilterForQuery.NamedDataExcludeFilter) {
+                            [Array] $PostNamedDataExclusions = @($FilterForQuery.NamedDataExcludeFilter)
+                            $FilterForQuery.Remove('NamedDataExcludeFilter')
+                        }
+                        $FilterXPath = Get-EventsFilter @FilterForQuery -XPathOnly
+                        if (-not $FilterXPath) {
+                            $FilterXPath = '*'
+                        }
+                        $SplatEvents = @{
+                            ErrorAction = 'Stop'
+                            Oldest      = $Oldest
+                            FilterXPath = $FilterXPath
+                        }
+                        if ($IsPathQuery) {
+                            $SplatEvents.Path = $EventFilter.Path
+                            Write-Verbose "Get-Events - Inside $Comp - Custom FilterXPath for path: `n$FilterXPath"
+                        } else {
+                            $SplatEvents.ProviderName = $EventFilter.ProviderName
+                            $SplatEvents.ComputerName = $Comp
+                            Write-Verbose "Get-Events - Inside $Comp - Custom FilterXPath for provider: `n$FilterXPath"
+                        }
+                    } else {
+                        $FilterXML = Get-EventsFilter @FilterForQuery
+                        $SplatEvents = @{
+                            ErrorAction  = 'Stop'
+                            ComputerName = $Comp
+                            Oldest       = $Oldest
+                            FilterXml    = $FilterXML
+                        }
+                        Write-Verbose "Get-Events - Inside $Comp - Custom FilterXML: `n$FilterXML"
+                    }
                 } else {
                     $SplatEvents = @{
                         ErrorAction     = 'Stop'
@@ -716,7 +750,7 @@ $Script:ScriptBlock = {
                         Write-Verbose "Get-Events - Inside $Comp Data in FilterHashTable $k $($EventFilter[$k])"
                     }
                 }
-                if ($MaxEvents -ne 0) {
+                if ($MaxEvents -ne 0 -and -not $PostFilterProvider -and $PostNamedDataExclusions.Count -eq 0) {
                     $SplatEvents.MaxEvents = $MaxEvents
                     Write-Verbose "Get-Events - Inside $Comp for Events Max Events: $MaxEvents"
                 }
@@ -724,7 +758,69 @@ $Script:ScriptBlock = {
                     $SplatEvents.Credential = $Credential
                     Write-Verbose "Get-Events - Inside $Comp for Events Credential: $Credential"
                 }
-                Get-WinEvent @SplatEvents
+                [Array] $QueriedEvents = @(Get-WinEvent @SplatEvents)
+                if ($PostFilterProvider -or $PostNamedDataExclusions.Count -gt 0) {
+                    [Array] $PostFilteredEvents = ForEach ($QueriedEvent in $QueriedEvents) {
+                        [bool] $ProviderMatched = -not $PostFilterProvider
+                        if ($PostFilterProvider) {
+                            ForEach ($ProviderPattern in $ProviderPatterns) {
+                                if ($QueriedEvent.ProviderName -like $ProviderPattern) {
+                                    $ProviderMatched = $true
+                                    break
+                                }
+                            }
+                        }
+                        [bool] $Excluded = $false
+                        if ($ProviderMatched -and $PostNamedDataExclusions.Count -gt 0) {
+                            [xml] $QueriedEventXml = $QueriedEvent.ToXml()
+                            ForEach ($Exclusion in $PostNamedDataExclusions) {
+                                [bool] $AllKeysMatch = $true
+                                ForEach ($Key in $Exclusion.Keys) {
+                                    [Array] $DataNodes = ForEach ($CandidateDataNode in @($QueriedEventXml.Event.EventData.Data)) {
+                                        if ($CandidateDataNode.Name -eq [String] $Key) {
+                                            $CandidateDataNode
+                                        }
+                                    }
+                                    [Array] $ExpectedValues = @($Exclusion[$Key])
+                                    if ($ExpectedValues.Count -eq 0 -or ($Exclusion[$Key] -is [String] -and $Exclusion[$Key].Length -eq 0)) {
+                                        [bool] $KeyMatches = $DataNodes.Count -gt 0
+                                    } else {
+                                        [bool] $KeyMatches = $false
+                                        ForEach ($DataNode in $DataNodes) {
+                                            ForEach ($ExpectedValue in $ExpectedValues) {
+                                                if ([String] $DataNode.'#text' -ceq [String] $ExpectedValue) {
+                                                    $KeyMatches = $true
+                                                    break
+                                                }
+                                            }
+                                            if ($KeyMatches) {
+                                                break
+                                            }
+                                        }
+                                    }
+                                    if (-not $KeyMatches) {
+                                        $AllKeysMatch = $false
+                                        break
+                                    }
+                                }
+                                if ($AllKeysMatch) {
+                                    $Excluded = $true
+                                    break
+                                }
+                            }
+                        }
+                        if ($ProviderMatched -and -not $Excluded) {
+                            $QueriedEvent
+                        }
+                    }
+                    if ($MaxEvents -ne 0) {
+                        $PostFilteredEvents | Select-Object -First $MaxEvents
+                    } else {
+                        $PostFilteredEvents
+                    }
+                } else {
+                    $QueriedEvents
+                }
             )
             #$EventsCount = ($Events | Measure-Object).Count
             Write-Verbose -Message "Get-Events - Inside $Comp Events found $($Events.Count)"

--- a/Private/ScriptBlock.ps1
+++ b/Private/ScriptBlock.ps1
@@ -224,6 +224,34 @@ $Script:ScriptBlock = {
         )
 
         #region Function definitions
+        Function ConvertTo-XPathXmlLiteral {
+            Param (
+                [AllowEmptyString()]
+                [String] $Value
+            )
+
+            $SingleQuote = [Char] 39
+            $DoubleQuote = [Char] 34
+            If (-not $Value.Contains([String] $SingleQuote)) {
+                $Literal = [String] $SingleQuote + $Value + [String] $SingleQuote
+            } ElseIf (-not $Value.Contains([String] $DoubleQuote)) {
+                $Literal = [String] $DoubleQuote + $Value + [String] $DoubleQuote
+            } Else {
+                $Parts = $Value.Split($SingleQuote)
+                [Array] $Segments = For ($Index = 0; $Index -lt $Parts.Length; $Index++) {
+                    If ($Parts[$Index].Length -gt 0) {
+                        [String] $SingleQuote + $Parts[$Index] + [String] $SingleQuote
+                    }
+                    If ($Index -lt $Parts.Length - 1) {
+                        [String] $DoubleQuote + [String] $SingleQuote + [String] $DoubleQuote
+                    }
+                }
+                $Literal = 'concat(' + ($Segments -join ',') + ')'
+            }
+
+            [System.Security.SecurityElement]::Escape($Literal)
+        }
+
         Function Join-XPathFilter {
             Param
             (
@@ -290,13 +318,16 @@ $Script:ScriptBlock = {
                 [String]
                 $Logic = 'or',
 
-                [switch]$NoParenthesis
+                [switch]$NoParenthesis,
+
+                [switch]$EscapeItems
             )
 
             $filter = ''
 
             ForEach ($item in $Items) {
-                $options = @{'NewFilter' = ($ForEachFormatString -f $item)
+                $FormattedItem = If ($EscapeItems) { ConvertTo-XPathXmlLiteral -Value ([String] $item) } Else { $item }
+                $options = @{'NewFilter' = ($ForEachFormatString -f $FormattedItem)
                     'ExistingFilter'     = $filter
                     'Logic'              = $logic
                     'NoParenthesis'      = $NoParenthesis
@@ -349,6 +380,7 @@ $Script:ScriptBlock = {
                 'Items'                = $ExcludeID
                 'ForEachFormatString'  = "EventID!={0}"
                 'FinalizeFormatString' = "*[System[{0}]]"
+                'Logic'                = 'and'
             }
             $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter (Initialize-XPathFilter @options)
         }
@@ -386,8 +418,9 @@ $Script:ScriptBlock = {
         If ($Data) {
             $options = @{
                 'Items'                = $Data
-                'ForEachFormatString'  = "Data='{0}'"
+                'ForEachFormatString'  = "Data={0}"
                 'FinalizeFormatString' = "*[EventData[{0}]]"
+                'EscapeItems'          = $true
             }
             $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter (Initialize-XPathFilter @options)
         }
@@ -397,8 +430,9 @@ $Script:ScriptBlock = {
         If ($ProviderName) {
             $options = @{
                 'Items'                = $ProviderName
-                'ForEachFormatString'  = "@Name='{0}'"
+                'ForEachFormatString'  = "@Name={0}"
                 'FinalizeFormatString' = "*[System[Provider[{0}]]]"
+                'EscapeItems'          = $true
             }
             $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter (Initialize-XPathFilter @options)
         }
@@ -487,8 +521,9 @@ $Script:ScriptBlock = {
 
             $options = @{
                 'Items'                = $sids
-                'ForEachFormatString'  = "@UserID='{0}'"
+                'ForEachFormatString'  = "@UserID={0}"
                 'FinalizeFormatString' = "*[System[Security[{0}]]]"
+                'EscapeItems'          = $true
             }
             $filter = Join-XPathFilter -ExistingFilter $filter -NewFilter (Initialize-XPathFilter @options)
         }
@@ -511,18 +546,21 @@ $Script:ScriptBlock = {
                                         #XPath for the Data node with that Name attribute
                                         #and value. Use 'and' logic to join the data values.
                                         #to the Name Attribute.
+                                        $KeyLiteral = ConvertTo-XPathXmlLiteral -Value ([String] $key)
                                         $options = @{
                                             'Items'                = $item[$key]
                                             'NoParenthesis'        = $true
-                                            'ForEachFormatString'  = "Data[@Name='$key'] = '{0}'"
+                                            'ForEachFormatString'  = "Data[@Name=$KeyLiteral] = {0}"
                                             'FinalizeFormatString' = "{0}"
+                                            'EscapeItems'          = $true
                                         }
                                         Initialize-XPathFilter @options
                                     } Else {
                                         #If there isn't a value for the key, create
                                         #XPath for the existence of the Data node with
                                         #that paritcular Name attribute.
-                                        "Data[@Name='$key']"
+                                        $KeyLiteral = ConvertTo-XPathXmlLiteral -Value ([String] $key)
+                                        "Data[@Name=$KeyLiteral]"
                                     }
                                 }
                             )
@@ -557,19 +595,22 @@ $Script:ScriptBlock = {
                                         #XPath for the Data node with that Name attribute
                                         #and value. Use 'and' logic to join the data values.
                                         #to the Name Attribute.
+                                        $KeyLiteral = ConvertTo-XPathXmlLiteral -Value ([String] $key)
                                         $options = @{
                                             'Items'                = $item[$key]
                                             'NoParenthesis'        = $true
-                                            'ForEachFormatString'  = "Data[@Name='$key'] != '{0}'"
+                                            'ForEachFormatString'  = "Data[@Name=$KeyLiteral] != {0}"
                                             'FinalizeFormatString' = "{0}"
                                             'Logic'                = 'and'
+                                            'EscapeItems'          = $true
                                         }
                                         Initialize-XPathFilter @options
                                     } Else {
                                         #If there isn't a value for the key, create
                                         #XPath for the existence of the Data node with
                                         #that paritcular Name attribute.
-                                        "Data[@Name='$key']"
+                                        $KeyLiteral = ConvertTo-XPathXmlLiteral -Value ([String] $key)
+                                        "Data[@Name=$KeyLiteral]"
                                     }
                                 }
                             )
@@ -693,8 +734,8 @@ $Script:ScriptBlock = {
             # Iterate through each one of the XML message properties
             #Add-Member -InputObject $Event -MemberType NoteProperty -Name "Computer" -Value $event.MachineName.ToString() -Force
             #Add-Member -InputObject $Event -MemberType NoteProperty -Name "Date" -Value $Event.TimeCreated -Force
-            $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('Computer', $event.MachineName.ToString()))
-            $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('Date', $Event.TimeCreated))
+            Add-Member -InputObject $Event -MemberType NoteProperty -Name 'Computer' -Value $event.MachineName.ToString() -Force
+            Add-Member -InputObject $Event -MemberType NoteProperty -Name 'Date' -Value $Event.TimeCreated -Force
 
             #$EventTopNodes = Get-Member -InputObject $eventXML.Event -MemberType Properties | Where-Object { $_.Name -ne 'System' -and $_.Name -ne 'xmlns' }
             $EventTopNodes = $eventXML.Event.PSAdapted.PSObject.Properties.Name #| Where-Object { $_ -ne 'System' -and $_ -ne 'xmlns' }
@@ -720,7 +761,7 @@ $Script:ScriptBlock = {
                             #$SubSubNode = Get-Member -InputObject $eventXML.Event.$TopNode.$SubNode -MemberType Properties | Where-Object { $_.Name -ne 'xmlns' -and $_.Definition -like "string*" }
                             $SubSubNode = $eventXML.Event.$TopNode.$SubNode.PSAdapted.PSObject.Properties #| Where-Object { $_.Name -ne 'xmlns' -and $_.TypeNameOfValue -like "string*" }
                             [Array] $SubSubNode = foreach ($Entry in $SubSubNode) {
-                                if ($Entry.Name -ne 'xmls' -and $_.TypeNameOfValue -like "string*") {
+                                if ($Entry.Name -ne 'xmls' -and $Entry.TypeNameOfValue -like "string*") {
                                     $Entry
                                 }
                             }
@@ -728,7 +769,7 @@ $Script:ScriptBlock = {
                                 $fieldName = $Name
                                 $fieldValue = $eventXML.Event.$TopNode.$SubNode.$Name
                                 #Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $fieldValue -Force
-                                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new($fieldName, $fieldValue))
+                                Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $fieldValue -Force
                             }
                             # Case 1
 
@@ -746,7 +787,7 @@ $Script:ScriptBlock = {
                                     }
                                     if ($fieldName -ne "") {
                                         #Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $fieldValue -Force
-                                        $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new($fieldName, $fieldValue))
+                                        Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $fieldValue -Force
                                     }
                                     # Case 2
                                 } else {
@@ -756,7 +797,7 @@ $Script:ScriptBlock = {
                                         $fieldName = "NoNameA$i"
                                         $fieldValue = $Value
                                         # Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $fieldValue -Force
-                                        $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new($fieldName, $fieldValue))
+                                        Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $fieldValue -Force
                                     }
                                     # Case 3
                                 }
@@ -765,10 +806,15 @@ $Script:ScriptBlock = {
                         }
                     } elseif ($EventSubSub.TypeNameOfValue -like "System.Xml.XmlElement*") {
                         # Case 1
+                        if ($SubNode -eq 'Data' -and $eventXML.Event.$TopNode.$SubNode.Name) {
+                            $fieldName = $eventXML.Event.$TopNode.$SubNode.Name
+                            $fieldValue = $eventXML.Event.$TopNode.$SubNode.'#text'
+                            Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $fieldValue -Force
+                        }
                         #$SubSubNode = Get-Member -InputObject $eventXML.Event.$TopNode.$SubNode -MemberType Properties | Where-Object { $_.Name -ne 'xmlns' -and $_.Definition -like "string*" }
                         $SubSubNode = $eventXML.Event.$TopNode.$SubNode.PSAdapted.PSObject.Properties #| Where-Object { $_.Name -ne 'xmlns' -and $_.TypeNameOfValue -like "string*" }
                         [Array] $SubSubNode = foreach ($Entry in $SubSubNode) {
-                            if ($Entry.Name -ne 'xmls' -and $_.TypeNameOfValue -like "string*") {
+                            if ($Entry.Name -ne 'xmls' -and $Entry.TypeNameOfValue -like "string*") {
                                 $Entry
                             }
                         }
@@ -776,7 +822,7 @@ $Script:ScriptBlock = {
                             $fieldName = $Name
                             $fieldValue = $eventXML.Event.$TopNode.$SubNode.$Name
                             # Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $fieldValue -Force
-                            $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new($fieldName, $fieldValue))
+                            Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $fieldValue -Force
                         }
                         # Case 1
                     } else {
@@ -789,13 +835,13 @@ $Script:ScriptBlock = {
                                 $h++
                                 $fieldName = "NoNameB$h"
                                 #Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $Split -Force
-                                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new($fieldName, $Split))
+                                Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $Split -Force
                             }
                         } else {
                             $h++
                             $fieldName = "NoNameB$h"
                             #Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $fieldValue -Force
-                            $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new($fieldName, $fieldValue))
+                            Add-Member -InputObject $Event -MemberType NoteProperty -Name $fieldName -Value $fieldValue -Force
                         }
                         # Case 4
                     }
@@ -805,43 +851,43 @@ $Script:ScriptBlock = {
             [string] $MessageSubject = ($Event.Message -split '\n')[0] -replace "`n", '' -replace "`r", '' -replace "`t", ''
             #Add-Member -InputObject $Event -MemberType NoteProperty -Name 'MessageSubject' -Value $MessageSubject -Force
             #Add-Member -InputObject $Event -MemberType NoteProperty -Name 'Action' -Value $MessageSubject -Force
-            $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('MessageSubject', $MessageSubject))
-            $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('Action', $MessageSubject))
+            Add-Member -InputObject $Event -MemberType NoteProperty -Name 'MessageSubject' -Value $MessageSubject -Force
+            Add-Member -InputObject $Event -MemberType NoteProperty -Name 'Action' -Value $MessageSubject -Force
 
             # Level value is not needed because there is actually LevelDisplayName
             #Add-Member -InputObject $Event -MemberType NoteProperty -Name 'LevelTranslated' -Value ([PSEventViewer.Level] $Event.Level)
 
             # Overwrite value - the old value is collection
             # Add-Member -InputObject $Event -MemberType NoteProperty -Name 'KeywordDisplayName' -Value ($Event.KeywordsDisplayNames -join ',') -Force
-            $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('KeywordDisplayName', ($Event.KeywordsDisplayNames -join ',')))
+            Add-Member -InputObject $Event -MemberType NoteProperty -Name 'KeywordDisplayName' -Value ($Event.KeywordsDisplayNames -join ',') -Force
 
             if ($Event.SubjectDomainName -and $Event.SubjectUserName) {
                 #Add-Member -InputObject $Event -MemberType NoteProperty -Name 'Who' -Value "$($Event.SubjectDomainName)\$($Event.SubjectUserName)" -Force
-                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('Who', "$($Event.SubjectDomainName)\$($Event.SubjectUserName)" ))
+                Add-Member -InputObject $Event -MemberType NoteProperty -Name 'Who' -Value "$($Event.SubjectDomainName)\$($Event.SubjectUserName)" -Force
             } elseif ($Event.SubjectUserName) {
-                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('Who', "$($Event.SubjectUserName)"))
+                Add-Member -InputObject $Event -MemberType NoteProperty -Name 'Who' -Value "$($Event.SubjectUserName)" -Force
             }
             if ($Event.TargetDomainName -and $Event.TargetUserName) {
                 #Add-Member -InputObject $Event -MemberType NoteProperty -Name 'ObjectAffected' -Value "$($Event.TargetDomainName)\$($Event.TargetUserName)" -Force
-                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('ObjectAffected', "$($Event.TargetDomainName)\$($Event.TargetUserName)"))
+                Add-Member -InputObject $Event -MemberType NoteProperty -Name 'ObjectAffected' -Value "$($Event.TargetDomainName)\$($Event.TargetUserName)" -Force
             } elseif ($Event.TargetUserName) {
                 # Add-Member -InputObject $Event -MemberType NoteProperty -Name 'ObjectAffected' -Value "$($Event.TargetUserName)" -Force
-                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('ObjectAffected', "$($Event.TargetUserName)"))
+                Add-Member -InputObject $Event -MemberType NoteProperty -Name 'ObjectAffected' -Value "$($Event.TargetUserName)" -Force
             }
             if ($Event.MemberName) {
                 [string] $MemberNameWithoutCN = $Event.MemberName -replace 'CN=|\\|,(OU|DC|CN).*$'
                 #Add-Member -InputObject $Event -MemberType NoteProperty -Name 'MemberNameWithoutCN' -Value $MemberNameWithoutCN -Force
-                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('MemberNameWithoutCN', $MemberNameWithoutCN))
+                Add-Member -InputObject $Event -MemberType NoteProperty -Name 'MemberNameWithoutCN' -Value $MemberNameWithoutCN -Force
             }
             if ($EventFilter.Path) {
                 #Add-Member -InputObject $Event -MemberType NoteProperty -Name "GatheredFrom" -Value $EventFilter.Path -Force
-                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('GatheredFrom', $EventFilter.Path))
+                Add-Member -InputObject $Event -MemberType NoteProperty -Name 'GatheredFrom' -Value $EventFilter.Path -Force
             } else {
                 #Add-Member -InputObject $Event -MemberType NoteProperty -Name "GatheredFrom" -Value $Comp -Force
-                $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('GatheredFrom', $Comp))
+                Add-Member -InputObject $Event -MemberType NoteProperty -Name 'GatheredFrom' -Value $Comp -Force
             }
             #Add-Member -InputObject $Event -MemberType NoteProperty -Name "GatheredLogName" -Value $EventFilter.LogName -Force
-            $Event.PSObject.Properties.Add([System.Management.Automation.PSNoteProperty]::new('GatheredLogName', $EventFilter.LogName))
+            Add-Member -InputObject $Event -MemberType NoteProperty -Name 'GatheredLogName' -Value $EventFilter.LogName -Force
         }
         Write-Verbose "Get-Events - Inside $Comp Time to generate $($Measure.Elapsed.Hours) hours, $($Measure.Elapsed.Minutes) minutes, $($Measure.Elapsed.Seconds) seconds, $($Measure.Elapsed.Milliseconds) milliseconds"
         $Measure.Stop()

--- a/Private/Test-Prerequisite.ps1
+++ b/Private/Test-Prerequisite.ps1
@@ -13,13 +13,6 @@ Function Test-Prerequisite () {
     }
 
     Write-Color @script:WriteParameters "[i] ", "Testing for prerequisite availability..." -Color White, Yellow
-    $ImportPSEventViewer = Get-ModulesAvailability -Name "PSEventViewer"
-    If ($ImportPSEventViewer -eq $true) {
-        Write-Color @script:WriteParameters  "[+] ", "PSEventViewer", " module imported. Continuing..." -Color White, Green, White
-    } else {
-        Write-Color @script:WriteParameters  "[-] ", "PSEventViewer", " module not found." -Color White, Red, White
-    }
-
     $ImportPSADReporting = Get-ModulesAvailability -Name "PSWinReporting"
     If ($ImportPSADReporting -eq $true) {
         Write-Color @script:WriteParameters  "[+] ", "PSWinReporting", " module imported. Continuing..." -Color White, Green, White
@@ -58,7 +51,7 @@ Function Test-Prerequisite () {
         $AdIsAvailable = $false
     }
 
-    if ($ImportPSEventViewer -eq $true -and $ImportPSADReporting -eq $true -and $ImportActiveDirectory -eq $true -and (($ReportOptions.AsExcel -eq $true -and $ImportExcel -eq $true) -or $ReportOptions.AsExcel -eq $false) -and $AdIsAvailable -eq $true) {
+    if ($ImportPSADReporting -eq $true -and $ImportActiveDirectory -eq $true -and (($ReportOptions.AsExcel -eq $true -and $ImportExcel -eq $true) -or $ReportOptions.AsExcel -eq $false) -and $AdIsAvailable -eq $true) {
         return #$true
     } else {
         Exit

--- a/Public/Start-ADReporting.ps1
+++ b/Public/Start-ADReporting.ps1
@@ -10,7 +10,7 @@ function Start-ADReporting () {
 
     if ($ReportOptions.DisplayConsole -and $ReportOptions.DisplayConsole.LogFile) {
         $ReportPath = [io.path]::GetDirectoryName($ReportOptions.DisplayConsole.LogFile)
-        if (-not (Test-Path -LiteralPath $ReportPath)) {
+        if (-not [String]::IsNullOrWhiteSpace($ReportPath) -and -not (Test-Path -LiteralPath $ReportPath)) {
             Write-Color -Text '[i] ', "LogFile path doesn't exists ", $ReportPath, ". Please fix log path or provide an empty string. Current log file: ", $ReportOptions.DisplayConsole.LogFile -Color White, White, Yellow, White, Yellow
             return
             #$null = New-Item -Path $ReportPath -ItemType Directory -Force


### PR DESCRIPTION
## Summary

- prepare the final PSWinReporting 1.x maintenance release as version 1.8.1.7
- pin PSWriteExcel 0.1.15, PSSharedGoods 0.0.312, and PSWriteColor 1.0.3 as exact runtime dependencies
- carry the last compatible event-query engine and the legacy private credential helper in the module source
- remove the obsolete PSEventViewer prerequisite and point release metadata at the future EventViewerX repository

## Compatibility

The package keeps the existing eight public commands and supports Windows PowerShell 5.1 and PowerShell 7. Its private event reader preserves archive-path queries, event-ID and record-ID combinations, wildcard logs and providers, the legacy `Computer` and `Date` fields, named event data, zero-valued levels and keywords, and per-request limits across split and parallel queries.

The frozen email, SQL, and logging paths retain distinct message encodings, surface metadata lookup failures, and accept filename-only log paths. Required legacy dependency versions remain exact and are included in the unpacked release artifact.

Publishing remains disabled. This PR prepares the final package but does not publish it.