### PR TITLE
fix(release): align EventViewerX package versions

### DIFF
--- a/Sources/Build/project.build.json
+++ b/Sources/Build/project.build.json
@@ -9,6 +9,7 @@
   },
   "ExpectedVersionMapAsInclude": true,
   "ExpectedVersionMapUseWildcards": false,
+  "AlignPackageVersions": true,
   "NugetSource": [],
   "IncludePrerelease": false,
   "Configuration": "Release",


### PR DESCRIPTION
## Summary

- align `EventViewerX`, `EventViewerX.Reporting`, and `EventViewerX.Storage` to one coordinated release version
- keep the PowerShell module and NuGet package family on the same release line

## Release behavior

PowerForge now selects the highest version required by the shared `4.0.X` release group and applies it consistently across the package family. The existing coordinated release order remains NuGet, PowerShell Gallery, then GitHub.

No packages are published by this change.